### PR TITLE
TECH-811: Update use of NEXUS_INTERNAL_RELEASES_URL for update signature action

### DIFF
--- a/update-signature/action.yml
+++ b/update-signature/action.yml
@@ -13,7 +13,7 @@ inputs:
   nexus_internal_releases_url:
     description: Nexus Enterprise release URL
     required: false
-    default: ${{secrets.NEXUS_INTERNAL_RELEASES_URL}}
+    default: 'https://devtools.jahia.com/nexus/content/repositories/jahia-internal-releases'
   nexus_username:
     description: Nexus Username
     required: true

--- a/update-signature/action.yml
+++ b/update-signature/action.yml
@@ -10,9 +10,10 @@ inputs:
     description: Regular expression of folders to not analyze when looking for module to sign
     required: false
     default: '*'
-  nexus_enterprise_releases_url:
+  nexus_internal_releases_url:
     description: Nexus Enterprise release URL
-    required: true
+    required: false
+    default: ${{secrets.NEXUS_INTERNAL_RELEASES_URL}}
   nexus_username:
     description: Nexus Username
     required: true
@@ -77,7 +78,7 @@ runs:
       if: env.PERFORM_SIGNATURE == 'true'
       run: |
         mkdir -p target/keymaker
-        url="${{ inputs.nexus_enterprise_releases_url }}/content/${{ inputs.keymaker_location }}/${{ inputs.keymaker_version }}/${{ inputs.keymaker_name }}-${{ inputs.keymaker_version }}-jar-with-dependencies.jar"
+        url="${{ inputs.nexus_internal_releases_url }}/${{ inputs.keymaker_location }}/${{ inputs.keymaker_version }}/${{ inputs.keymaker_name }}-${{ inputs.keymaker_version }}-jar-with-dependencies.jar"
         curl --header "Authorization: Basic $(echo -n "${{ inputs.nexus_username }}:${{ inputs.nexus_password }}" | base64)" \
             --url "${url}" \
             --output "target/keymaker/${{ inputs.keymaker_name }}.jar"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-811

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

From the ticket, `keymaker/cli` artifacts has been moved to nexus internal repository and needs to be reflected in the update-signature action.

Use a default value to fix issue for all modules.

 * `NEXUS_INTERNAL_RELEASES_URL` has been set to `https://devtools.jahia.com/nexus/content/repositories/jahia-internal-releases` (https://support.jahia.com/browse/INFRA-2276)
     * Note that this value has been hardcoded as we can't refer to secrets within an action. Will need to do some clean-up after https://jira.jahia.org/browse/TECH-827
 * curl url has been updated to https://devtools.jahia.com/nexus/content/repositories/jahia-internal-releases/org/jahia/keymaker/keymaker-cli/2.0/keymaker-cli-2.0-jar-with-dependencies.jar

This change will give a warning when run in module workflows and passing `nexus_enterprise_releases_url` parameter, but should still proceed to execute the action. 