### PR TITLE
BACKLOG-19964: Added a filter before triggering the push

### DIFF
--- a/docker-tags/action.yml
+++ b/docker-tags/action.yml
@@ -106,6 +106,16 @@ runs:
     - name: Generate Docker tags
       shell: bash
       run: |
+        # Only tagging images following format 1.2.3.4 or 1.2.3.4-SNAPSHOT
+        # Other versions (such as 1.2.3.4-SNAPSHOT-branch) are silently ignored
+        VERSION_FILTER=$(echo ${{ env.PARAM_VERSION }} | grep -E "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+${{ env.PARAM_VERSION_CLASSIFIER }}$" | wc -c | xargs)
+        if [[ "${{ env.PARAM_VERSION }}" == *"SNAPSHOT"* && "$VERSION_FILTER" == "0" ]]; then
+          echo "$(date +'%d %B %Y - %k:%M') - Version ${{ env.PARAM_VERSION }} appears to be built from a branch"
+          echo "$(date +'%d %B %Y - %k:%M') - The action is only meant at tagging release or snapshot versions (1.2.3.4 or 1.2.3.4-SNAPSHOT)"
+          echo "$(date +'%d %B %Y - %k:%M') - The action will SILENTLY EXIT"
+          exit 0
+        fi
+
         echo "$(date +'%d %B %Y - %k:%M') - GetVersions: Fetching container versions from container registry: ${{ env.AUTH_SERVICE }}"
         VERSIONS=$(curl -s -H "Authorization: Bearer ${{ env.TOKEN }}" https://${{ env.API_DOMAIN }}/v2/"${{ env.PARAM_ORG }}"/"${{ env.PARAM_REPO }}"/tags/list | jq -r '.tags[]' | grep -E "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+${{ env.PARAM_VERSION_CLASSIFIER }}$")
         echo "$(date +'%d %B %Y - %k:%M') - GetVersions: Fetch complete"


### PR DESCRIPTION
There was an issue in which a the tag action was trying to alias an image built from a branch