### PR TITLE
Removing yarn which is not needed here

### DIFF
--- a/static-analysis/action.yml
+++ b/static-analysis/action.yml
@@ -46,7 +46,6 @@ runs:
     - uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node_version }}
-        cache: yarn
 
     # Install node dependencies
     - name: Run yarn if package.json exists in module folder


### PR DESCRIPTION
This was introduced recently, this option aims at caching the dependencies (I guess for in-between jobs), since all steps are executed in the same job, this shouldn't be necessary.