### PR TITLE
TECH-1147: Added the handling for a test artifact to be built and usable in the integration tests

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -69,10 +69,8 @@ runs:
       shell: bash
       if: steps.check_test_module.outputs.files_exists == 'true'
       run: |
-        # Save current project folder
         ROOT_PATH=$(pwd)
         cd ${{ inputs.tests_module_path }}
-        echo "Building test module"
         mvn -B -U -ntp -s $ROOT_PATH/${{ inputs.mvn_settings_filepath }} clean install
 
     - name: Prepare artifacts

--- a/build/action.yml
+++ b/build/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'Time during which artifact are kept in Github infrastructure'
     required: false
     default: '2'
+  tests_module_path:
+    description: 'Path to a folder in the repository containing a tests module to be built'
+    required: false
+    default: 'tests/jahia-module/'    
 
 runs:
   using: 'composite'
@@ -54,6 +58,20 @@ runs:
     - name: Copy dependencies to provision artifacts
       shell: bash
       run: mvn -B -s ${{ inputs.mvn_settings_filepath }} dependency:copy-dependencies -DexcludeTransitive=true -DincludeScope=provided -DincludeGroupIds=org.jahia.modules -DincludeTypes=jar
+
+    - name: Check if test module is present
+      id: check_test_module
+      uses: andstor/file-existence-action@v2
+      with:
+        files: "${{ inputs.tests_module_path }}pom.xml"
+
+    - name: Build tests package
+      shell: bash
+      if: steps.check_test_module.outputs.files_exists == 'true'
+      run: |
+        cd ${{ inputs.tests_module_path }}
+        echo "Building test module"
+        mvn -B -U -ntp -s ${{ inputs.mvn_settings_filepath }} clean install
 
     - name: Prepare artifacts
       shell: bash

--- a/build/action.yml
+++ b/build/action.yml
@@ -71,6 +71,7 @@ runs:
       run: |
         cd ${{ inputs.tests_module_path }}
         echo "Building test module"
+        ls -lah ${{ github.workspace }}/
         mvn -B -U -ntp -s ${{ github.workspace }}/${{ inputs.mvn_settings_filepath }} clean install
 
     - name: Prepare artifacts

--- a/build/action.yml
+++ b/build/action.yml
@@ -73,26 +73,6 @@ runs:
         cd ${{ inputs.tests_module_path }}
         mvn -B -U -ntp -s $ROOT_PATH/${{ inputs.mvn_settings_filepath }} clean install
 
-    # This whole section might actually be redundant with the paths defined 
-    # in the upload-artifact action
-    - name: Prepare artifacts
-      shell: bash
-      run: |
-        mkdir /tmp/artifacts/
-        find . -type f -path '*/target/*-SNAPSHOT*.jar' -exec cp '{}' /tmp/artifacts/ ';' || :
-        if [ -f target/*source-release.zip ]; then
-          echo "A source file is present, copying it to the artifacts folder"
-          cp target/*source-release.zip /tmp/artifacts/ || :
-        fi
-        if [ -d ${{ inputs.module_id }}/ ]; then
-          echo "Copying jar from: ${{ inputs.module_id }}/"
-          cp ${{ inputs.module_id }}/target/*.jar /tmp/artifacts/ || :
-          if [ ! -d target/ ]; then
-            mkdir target/
-          fi
-          cp ${{ inputs.module_id }}/target/*.jar target/ || :
-        fi
-
     - name: Archive build artifacts
       if: always()
       uses: actions/upload-artifact@v3

--- a/build/action.yml
+++ b/build/action.yml
@@ -73,6 +73,7 @@ runs:
         cd ${{ inputs.tests_module_path }}
         mvn -B -U -ntp -s $ROOT_PATH/${{ inputs.mvn_settings_filepath }} clean install
 
+
     - name: Prepare artifacts
       shell: bash
       run: |
@@ -92,10 +93,10 @@ runs:
         fi
         if [ "${{ steps.check_test_module.outputs.files_exists }}" == "true" ]; then
           cd ${{ inputs.tests_module_path }}
-          find . -type f -path '*/target/*-SNAPSHOT*.jar' -exec cp '{}' /tmp/artifacts/ ';' || :
+          find . -type f -path '${{ inputs.tests_module_path }}/target/*-SNAPSHOT*.jar' -exec cp '{}' target/ ';' || :
         fi
-        echo "Displaying the content of /tmp/artifacts"
-        ls -lah /tmp/artifacts
+        echo "Displaying the content of target/"
+        ls -lah target/
 
     - name: Archive build artifacts
       if: always()

--- a/build/action.yml
+++ b/build/action.yml
@@ -71,7 +71,7 @@ runs:
       run: |
         cd ${{ inputs.tests_module_path }}
         echo "Building test module"
-        mvn -B -U -ntp -s ${{ github.workspace }}${{ inputs.mvn_settings_filepath }} clean install
+        mvn -B -U -ntp -s ${{ github.workspace }}/${{ inputs.mvn_settings_filepath }} clean install
 
     - name: Prepare artifacts
       shell: bash

--- a/build/action.yml
+++ b/build/action.yml
@@ -92,7 +92,8 @@ runs:
           cp ${{ inputs.module_id }}/target/*.jar target/ || :
         fi
         if [ "${{ steps.check_test_module.outputs.files_exists }}" == "true" ]; then
-          find . -type f -path '${{ inputs.tests_module_path }}/target/*-SNAPSHOT*.jar' -exec cp '{}' target/ ';' || :
+          echo "Copying test artifacts"
+          find . -type f -path '${{ inputs.tests_module_path }}target/*-SNAPSHOT*.jar' -exec cp '{}' target/ ';' || :
         fi
         echo "Displaying the content of target/"
         ls -lah target/

--- a/build/action.yml
+++ b/build/action.yml
@@ -94,6 +94,7 @@ runs:
         if [ "${{ steps.check_test_module.outputs.files_exists }}" == "true" ]; then
           echo "Copying test artifacts"
           find . -type f -path '${{ inputs.tests_module_path }}target/*-SNAPSHOT*.jar' -exec cp '{}' target/ ';' || :
+          find . -type f -path '${{ inputs.tests_module_path }}*/target/*-SNAPSHOT*.jar' -exec cp '{}' target/ ';' || :
         fi
         echo "Displaying the content of target/"
         ls -lah target/

--- a/build/action.yml
+++ b/build/action.yml
@@ -92,11 +92,10 @@ runs:
           cp ${{ inputs.module_id }}/target/*.jar target/ || :
         fi
         if [ "${{ steps.check_test_module.outputs.files_exists }}" == "true" ]; then
-          cd ${{ inputs.tests_module_path }}
-          find . -type f -path '${{ inputs.tests_module_path }}/target/*-SNAPSHOT*.jar' -exec cp '{}' /tmp/artifacts/ ';' || :
+          find . -type f -path '${{ inputs.tests_module_path }}/target/*-SNAPSHOT*.jar' -exec cp '{}' target/ ';' || :
         fi
         echo "Displaying the content of target/"
-        ls -lah /tmp/artifacts/
+        ls -lah target/
 
     - name: Archive build artifacts
       if: always()
@@ -106,7 +105,6 @@ runs:
         path: |
           target/*
           ./*/target/*
-          /tmp/artifacts/
         retention-days: ${{ inputs.github_artifact_retention }}
 
     - name: Keep session opened if /tmp/debug file is present

--- a/build/action.yml
+++ b/build/action.yml
@@ -69,10 +69,11 @@ runs:
       shell: bash
       if: steps.check_test_module.outputs.files_exists == 'true'
       run: |
+        # Save current project folder
+        ROOT_PATH=$(pwd)
         cd ${{ inputs.tests_module_path }}
         echo "Building test module"
-        ls -lah ${{ github.workspace }}/
-        mvn -B -U -ntp -s ${{ github.workspace }}/${{ inputs.mvn_settings_filepath }} clean install
+        mvn -B -U -ntp -s $ROOT_PATH/${{ inputs.mvn_settings_filepath }} clean install
 
     - name: Prepare artifacts
       shell: bash

--- a/build/action.yml
+++ b/build/action.yml
@@ -73,7 +73,8 @@ runs:
         cd ${{ inputs.tests_module_path }}
         mvn -B -U -ntp -s $ROOT_PATH/${{ inputs.mvn_settings_filepath }} clean install
 
-
+    # This whole section might actually be redundant with the paths defined 
+    # in the upload-artifact action
     - name: Prepare artifacts
       shell: bash
       run: |
@@ -91,13 +92,6 @@ runs:
           fi
           cp ${{ inputs.module_id }}/target/*.jar target/ || :
         fi
-        if [ "${{ steps.check_test_module.outputs.files_exists }}" == "true" ]; then
-          echo "Copying test artifacts"
-          find . -type f -path '${{ inputs.tests_module_path }}target/*-SNAPSHOT*.jar' -exec cp '{}' target/ ';' || :
-          find . -type f -path '${{ inputs.tests_module_path }}*/target/*-SNAPSHOT*.jar' -exec cp '{}' target/ ';' || :
-        fi
-        echo "Displaying the content of target/"
-        ls -lah target/
 
     - name: Archive build artifacts
       if: always()
@@ -106,7 +100,8 @@ runs:
         name: build-artifacts
         path: |
           target/*
-          ./*/target/*
+          **/target/*.jar
+          **/*source-release.zip
         retention-days: ${{ inputs.github_artifact_retention }}
 
     - name: Keep session opened if /tmp/debug file is present

--- a/build/action.yml
+++ b/build/action.yml
@@ -93,10 +93,10 @@ runs:
         fi
         if [ "${{ steps.check_test_module.outputs.files_exists }}" == "true" ]; then
           cd ${{ inputs.tests_module_path }}
-          find . -type f -path '${{ inputs.tests_module_path }}/target/*-SNAPSHOT*.jar' -exec cp '{}' target/ ';' || :
+          find . -type f -path '${{ inputs.tests_module_path }}/target/*-SNAPSHOT*.jar' -exec cp '{}' /tmp/artifacts/ ';' || :
         fi
         echo "Displaying the content of target/"
-        ls -lah target/
+        ls -lah /tmp/artifacts/
 
     - name: Archive build artifacts
       if: always()
@@ -106,6 +106,7 @@ runs:
         path: |
           target/*
           ./*/target/*
+          /tmp/artifacts/
         retention-days: ${{ inputs.github_artifact_retention }}
 
     - name: Keep session opened if /tmp/debug file is present

--- a/build/action.yml
+++ b/build/action.yml
@@ -71,7 +71,7 @@ runs:
       run: |
         cd ${{ inputs.tests_module_path }}
         echo "Building test module"
-        mvn -B -U -ntp -s ${{ inputs.mvn_settings_filepath }} clean install
+        mvn -B -U -ntp -s ${{ github.workspace }}${{ inputs.mvn_settings_filepath }} clean install
 
     - name: Prepare artifacts
       shell: bash
@@ -90,6 +90,12 @@ runs:
           fi
           cp ${{ inputs.module_id }}/target/*.jar target/ || :
         fi
+        if [ "${{ steps.check_test_module.outputs.files_exists }}" == "true" ]; then
+          cd ${{ inputs.tests_module_path }}
+          find . -type f -path '*/target/*-SNAPSHOT*.jar' -exec cp '{}' /tmp/artifacts/ ';' || :
+        fi
+        echo "Displaying the content of /tmp/artifacts"
+        ls -lah /tmp/artifacts
 
     - name: Archive build artifacts
       if: always()

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -36,6 +36,20 @@ runs:
       shell: bash
       run: mvn -B -s ${{ inputs.mvn_settings_filepath }} clean deploy | tee mvnLogs.txt
 
+    - name: Check if test module is present
+      id: check_test_module
+      uses: andstor/file-existence-action@v2
+      with:
+        files: "${{ inputs.tests_module_path }}pom.xml"
+
+    - name: Publish tests package (if present)
+      shell: bash
+      if: steps.check_test_module.outputs.files_exists == 'true'
+      run: |
+        ROOT_PATH=$(pwd)
+        cd ${{ inputs.tests_module_path }}
+        mvn -B -U -ntp -s $ROOT_PATH/${{ inputs.mvn_settings_filepath }} clean deploy
+
     - name: Direct link location of the Artifact
       shell: bash
       run: |

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -12,6 +12,10 @@ inputs:
   nexus_password:
     description: 'Nexus Password'
     required: true
+  tests_module_path:
+    description: 'Path to a folder in the repository containing a tests module to be built'
+    required: false
+    default: 'tests/jahia-module/'  
 
 runs:
   using: "composite"


### PR DESCRIPTION
That artifact is added to the "build-artifacts" archive being used by the integration tests during the on-code-change and on-merge workflows.

For nightly, it will remain necessary to update each repo's snapshot manifest, but that can be done alongside the introduction of the test module in the repo.