### PR TITLE
TECH-1134: Fixed the execution on a maintenance branch

### DIFF
--- a/sonar-analysis/action.yml
+++ b/sonar-analysis/action.yml
@@ -131,9 +131,9 @@ runs:
           mvn -B -s ${{ inputs.mvn_settings_filepath }} sonar:sonar \
             $SONAR_PARAMS
         else
-          echo "Executing an analysis on branch: $GITHUB_REF"
+          echo "Executing an analysis on branch: ${{ inputs.primary_release_branch }}"
           mvn -B -s ${{ inputs.mvn_settings_filepath }} sonar:sonar \
-            -Dsonar.branch.name=$GITHUB_REF \
+            -Dsonar.branch.name=${{ inputs.primary_release_branch }} \
             $SONAR_PARAMS
         fi
 


### PR DESCRIPTION
The `$GITHUB_REF` variable is not updating after switching to a different branch, making it impossible to perform a scan when using a nightly workflow (for example).

This change covers this situation by using the variable provided during configuration.