### PR TITLE
Update release action to include test module

### DIFF
--- a/release/action.yml
+++ b/release/action.yml
@@ -131,7 +131,7 @@ runs:
         if [[ "${{ inputs.tests_module_type }}" == "mvn"  &&  "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
           echo "Release prepare for test module"
           cd ${{ inputs.tests_module_path }}
-          mvn -B -s ${{ env.GITHUB_WORKSPACE }}/${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
+          mvn -B -s ${{ github.workspace }}/${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
         else
           echo "No test module found"
         fi
@@ -165,7 +165,7 @@ runs:
         if [[ "${{ inputs.tests_module_type }}" == "mvn"  &&  "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
           echo "Perform release for test module"
           cd ${{ inputs.tests_module_path }}
-          mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
+          mvn -B -s ${{ github.workspace }}/${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
         else
           echo "No test module found"          
         fi

--- a/release/action.yml
+++ b/release/action.yml
@@ -112,7 +112,8 @@ runs:
       with:
         files: "${{ inputs.tests_module_path }}pom.xml"
 
-    - name: Release prepare version for ${{ inputs.release_version }}
+    - name: Prepare versioning variables
+      id: versions
       shell: bash
       run: |
         TAG_VERSION=$(echo ${{ inputs.release_version }})
@@ -129,21 +130,30 @@ runs:
         fi
         echo "FINAL_RELEASE_VERSION=${FINAL_RELEASE_VERSION}"
         echo "NEXT_DEVELOPMENT_VERSION=${NEXT_DEVELOPMENT_VERSION}"
+        echo "next_development_version=${NEXT_DEVELOPMENT_VERSION}" >> $GITHUB_OUTPUT
+        echo "final_release_version=${FINAL_RELEASE_VERSION}" >> $GITHUB_OUTPUT
+
+    - name: Release prepare version for ${{ inputs.release_version }}
+      shell: bash
+      run: |
+        echo "FINAL_RELEASE_VERSION=${{ steps.versions.outputs.final_release_version }}"
+        echo "NEXT_DEVELOPMENT_VERSION=${{ steps.versions.outputs.next_development_version }}"
         if [[ "${{ inputs.tests_module_type }}" == "mvn" && "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
           echo "Release prepare for test module"
           cd ${{ inputs.tests_module_path }}
           # We only want to generate one single tag (for both the module and the test module), thus not being able to use release:prepare
           # We need to update the version in the test module, then commit these changes.
-          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B release:update-versions -DdevelopmentVersion="$FINAL_RELEASE_VERSION"
+          # mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} release:update-versions -DdevelopmentVersion="${{ steps.versions.outputs.final_release_version }}"
+          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} versions:set -DnewVersion="${{ steps.versions.outputs.final_release_version }}"
           git add .
           git commit -m "[skip ci] [Test module] Update version of the test module to the release"
           git push
+          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} deploy
         else
           echo "No test module found"
         fi
         cd ${GITHUB_WORKSPACE}
-        mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin]"
-
+        mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion="${{ steps.versions.outputs.final_release_version }}" -DdevelopmentVersion="${{ steps.versions.outputs.next_development_version }}" -DscmCommentPrefix="[skip ci] [maven-release-plugin]"
 
     - name: Cache local Maven repository
       uses: actions/cache@v3
@@ -170,25 +180,24 @@ runs:
     - name: Perform release
       shell: bash
       run: | 
-        if [[ "${{ inputs.tests_module_type }}" == "mvn"  &&  "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
-          echo "Perform release for test module"
-          cd ${{ inputs.tests_module_path }}
-          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} release:perform -Prelease-to-staging-repository
-        else
-          echo "No test module found"          
-        fi
-        cd ${GITHUB_WORKSPACE}
+        # if [[ "${{ inputs.tests_module_type }}" == "mvn"  &&  "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
+        #   echo "Perform release for test module"
+        #   cd ${{ inputs.tests_module_path }}
+        #   mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} release:perform -Prelease-to-staging-repository
+        # else
+        #   echo "No test module found"          
+        # fi
+        # cd ${GITHUB_WORKSPACE}
         mvn -B -s ${{ inputs.mvn_settings_filepath }} release:perform -Prelease-to-staging-repository
 
     - name: Set development version for the test module (if present)
       shell: bash
       run: | 
         if [[ "${{ inputs.tests_module_type }}" == "mvn" && "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
-          echo "Release prepare for test module"
-          cd ${{ inputs.tests_module_path }}
-          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B release:update-versions -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION"
+          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} versions:set -DnewVersion="${{ steps.versions.outputs.next_development_version }}"
           git add .
-          git commit -m "[skip ci] [Test module] Set next development version"
+          # Note: We do want the CI to run to build the snapshot version of the test module
+          git commit -m "[Test module] Update version of the test module to the next development version"
           git push
         else
           echo "No test module found to set development version"

--- a/release/action.yml
+++ b/release/action.yml
@@ -131,7 +131,12 @@ runs:
           echo "Release prepare for test module"
           cd ${{ inputs.tests_module_path }}
           # mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
+          # We only want to generate one single tag (for both the module and the test module), thus not being able to use release:prepare
+          # We need to update the version in the test module, then commit these changes.
           mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B release:update-versions -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION"
+          git add .
+          git commit -m "[skip ci] Update version of the test module"
+          git push
         else
           echo "No test module found"
         fi

--- a/release/action.yml
+++ b/release/action.yml
@@ -196,6 +196,7 @@ runs:
       shell: bash
       run: | 
         if [[ "${{ inputs.tests_module_type }}" == "mvn" && "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
+          cd ${{ inputs.tests_module_path }}
           mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} versions:set -DnewVersion="${{ steps.versions.outputs.next_development_version }}"
           git add .
           # Note: We do want the CI to run to build the snapshot version of the test module

--- a/release/action.yml
+++ b/release/action.yml
@@ -130,7 +130,8 @@ runs:
         if [[ "${{ inputs.tests_module_type }}" == "mvn"  &&  "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
           echo "Release prepare for test module"
           cd ${{ inputs.tests_module_path }}
-          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
+          # mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
+          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B release:update-versions -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION"
         else
           echo "No test module found"
         fi

--- a/release/action.yml
+++ b/release/action.yml
@@ -145,7 +145,6 @@ runs:
           cd ${{ inputs.tests_module_path }}
           # We only want to generate one single tag (for both the module and the test module), thus not being able to use release:prepare
           # We need to update the version in the test module, then commit these changes.
-          # mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} release:update-versions -DdevelopmentVersion="${{ steps.versions.outputs.final_release_version }}"
           mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} versions:set -DnewVersion="${{ steps.versions.outputs.final_release_version }}"
           git add .
           git commit -m "[skip ci] [Test module] Update version of the test module to the release"

--- a/release/action.yml
+++ b/release/action.yml
@@ -128,11 +128,12 @@ runs:
           NEXT_DEVELOPMENT_VERSION="$MAJOR_VERSION.$MINOR_VERSION.$NEXT_REVISION"-SNAPSHOT
         fi
         mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin]"
-        echo "Release prepare for test module"
         if [[ "${{ inputs.tests_module_type }}" == "mvn"  &&  "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
+          echo "Release prepare for test module"
           cd ${{ inputs.tests_module_path }}
-
           mvn -B -s ${{ env.GITHUB_WORKSPACE }}/${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
+        else
+          echo "No test module found"
         fi
 
     - name: Cache local Maven repository
@@ -161,10 +162,12 @@ runs:
       shell: bash
       run: | 
         mvn -B -s ${{ inputs.mvn_settings_filepath }} release:perform -Prelease-to-staging-repository
-        echo "Perform release for test module"
         if [[ "${{ inputs.tests_module_type }}" == "mvn"  &&  "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
+          echo "Perform release for test module"
           cd ${{ inputs.tests_module_path }}
           mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
+        else
+          echo "No test module found"          
         fi
 
     - name: Copy artifacts

--- a/release/action.yml
+++ b/release/action.yml
@@ -132,12 +132,14 @@ runs:
         echo "NEXT_DEVELOPMENT_VERSION=${NEXT_DEVELOPMENT_VERSION}"
         echo "next_development_version=${NEXT_DEVELOPMENT_VERSION}" >> $GITHUB_OUTPUT
         echo "final_release_version=${FINAL_RELEASE_VERSION}" >> $GITHUB_OUTPUT
+        echo "tag_version=${TAG_VERSION}" >> $GITHUB_OUTPUT
 
     - name: Release prepare version for ${{ inputs.release_version }}
       shell: bash
       run: |
         echo "FINAL_RELEASE_VERSION=${{ steps.versions.outputs.final_release_version }}"
         echo "NEXT_DEVELOPMENT_VERSION=${{ steps.versions.outputs.next_development_version }}"
+        echo "TAG_VERSION=${{ steps.versions.outputs.tag_version }}"
         if [[ "${{ inputs.tests_module_type }}" == "mvn" && "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
           echo "Release prepare for test module"
           cd ${{ inputs.tests_module_path }}
@@ -153,7 +155,7 @@ runs:
           echo "No test module found"
         fi
         cd ${GITHUB_WORKSPACE}
-        mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion="${{ steps.versions.outputs.final_release_version }}" -DdevelopmentVersion="${{ steps.versions.outputs.next_development_version }}" -DscmCommentPrefix="[skip ci] [maven-release-plugin]"
+        mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=${{ steps.versions.outputs.tag_version }} release:prepare -DreleaseVersion="${{ steps.versions.outputs.final_release_version }}" -DdevelopmentVersion="${{ steps.versions.outputs.next_development_version }}" -DscmCommentPrefix="[skip ci] [maven-release-plugin]"
 
     - name: Cache local Maven repository
       uses: actions/cache@v3

--- a/release/action.yml
+++ b/release/action.yml
@@ -131,7 +131,7 @@ runs:
         if [[ "${{ inputs.tests_module_type }}" == "mvn"  &&  "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
           echo "Release prepare for test module"
           cd ${{ inputs.tests_module_path }}
-          mvn -B -s ${{ github.workspace }}/${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
+          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
         else
           echo "No test module found"
         fi
@@ -165,7 +165,7 @@ runs:
         if [[ "${{ inputs.tests_module_type }}" == "mvn"  &&  "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
           echo "Perform release for test module"
           cd ${{ inputs.tests_module_path }}
-          mvn -B -s ${{ github.workspace }}/${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
+          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
         else
           echo "No test module found"          
         fi

--- a/release/action.yml
+++ b/release/action.yml
@@ -127,14 +127,16 @@ runs:
           NEXT_REVISION=`expr $REVISION + 1`
           NEXT_DEVELOPMENT_VERSION="$MAJOR_VERSION.$MINOR_VERSION.$NEXT_REVISION"-SNAPSHOT
         fi
-        mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin]"
         if [[ "${{ inputs.tests_module_type }}" == "mvn"  &&  "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
           echo "Release prepare for test module"
           cd ${{ inputs.tests_module_path }}
-          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
+          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
         else
           echo "No test module found"
         fi
+        cd ${GITHUB_WORKSPACE}
+        mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin]"
+
 
     - name: Cache local Maven repository
       uses: actions/cache@v3
@@ -161,14 +163,16 @@ runs:
     - name: Perform release
       shell: bash
       run: | 
-        mvn -B -s ${{ inputs.mvn_settings_filepath }} release:perform -Prelease-to-staging-repository
         if [[ "${{ inputs.tests_module_type }}" == "mvn"  &&  "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
           echo "Perform release for test module"
           cd ${{ inputs.tests_module_path }}
-          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
+          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} release:perform -Prelease-to-staging-repository
         else
           echo "No test module found"          
         fi
+        cd ${GITHUB_WORKSPACE}
+        mvn -B -s ${{ inputs.mvn_settings_filepath }} release:perform -Prelease-to-staging-repository
+
 
     - name: Copy artifacts
       shell: bash

--- a/release/action.yml
+++ b/release/action.yml
@@ -127,15 +127,15 @@ runs:
           NEXT_REVISION=`expr $REVISION + 1`
           NEXT_DEVELOPMENT_VERSION="$MAJOR_VERSION.$MINOR_VERSION.$NEXT_REVISION"-SNAPSHOT
         fi
-        if [[ "${{ inputs.tests_module_type }}" == "mvn"  &&  "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
+        if [[ "${{ inputs.tests_module_type }}" == "mvn" && "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
           echo "Release prepare for test module"
           cd ${{ inputs.tests_module_path }}
           # mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
           # We only want to generate one single tag (for both the module and the test module), thus not being able to use release:prepare
           # We need to update the version in the test module, then commit these changes.
-          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B release:update-versions -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION"
+          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B release:update-versions -DdevelopmentVersion="$FINAL_RELEASE_VERSION"
           git add .
-          git commit -m "[skip ci] Update version of the test module"
+          git commit -m "[skip ci] [Test module] Update version of the test module to the release"
           git push
         else
           echo "No test module found"
@@ -179,6 +179,19 @@ runs:
         cd ${GITHUB_WORKSPACE}
         mvn -B -s ${{ inputs.mvn_settings_filepath }} release:perform -Prelease-to-staging-repository
 
+    - name: Set development version for the test module (if present)
+      shell: bash
+      run: | 
+        if [[ "${{ inputs.tests_module_type }}" == "mvn" && "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
+          echo "Release prepare for test module"
+          cd ${{ inputs.tests_module_path }}
+          mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B release:update-versions -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION"
+          git add .
+          git commit -m "[skip ci] [Test module] Set next development version"
+          git push
+        else
+          echo "No test module found to set development version"
+        fi
 
     - name: Copy artifacts
       shell: bash

--- a/release/action.yml
+++ b/release/action.yml
@@ -199,8 +199,7 @@ runs:
           cd ${{ inputs.tests_module_path }}
           mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} versions:set -DnewVersion="${{ steps.versions.outputs.next_development_version }}"
           git add .
-          # Note: We do want the CI to run to build the snapshot version of the test module
-          git commit -m "[Test module] Update version of the test module to the next development version"
+          git commit -m "[skip ci] [Test module] Update version of the test module to the next development version"
           git push
         else
           echo "No test module found to set development version"

--- a/release/action.yml
+++ b/release/action.yml
@@ -131,7 +131,8 @@ runs:
         echo "Release prepare for test module"
         if [[ "${{ inputs.tests_module_type }}" == "mvn"  &&  "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
           cd ${{ inputs.tests_module_path }}
-          mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
+
+          mvn -B -s ${{ env.GITHUB_WORKSPACE }}/${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
         fi
 
     - name: Cache local Maven repository

--- a/release/action.yml
+++ b/release/action.yml
@@ -16,6 +16,14 @@ inputs:
   nexus_password:
     description: 'Nexus Password'
     required: true
+  tests_module_path:
+    description: 'Path to a folder in the repository containing a tests module to be built (Both NPM and MVN test module supported)'
+    required: false
+    default: 'tests/jahia-module/'
+  tests_module_type:
+    description: 'Type of module for the tests module (mvn,npm)'
+    required: false
+    default: 'mvn'    
   github_slug:
     description: 'GitHub SLUG of the module (for example: jahia/sandbox)'
     required: true
@@ -97,6 +105,13 @@ runs:
         echo "---"
         git show --summary
 
+    - name: Check if test module is present (MVN)
+      if: ${{ inputs.tests_module_type == 'mvn' }}
+      id: check_test_module_mvn
+      uses: andstor/file-existence-action@v2
+      with:
+        files: "${{ inputs.tests_module_path }}pom.xml"
+
     - name: Release prepare version for ${{ inputs.release_version }}
       shell: bash
       run: |
@@ -113,6 +128,11 @@ runs:
           NEXT_DEVELOPMENT_VERSION="$MAJOR_VERSION.$MINOR_VERSION.$NEXT_REVISION"-SNAPSHOT
         fi
         mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin]"
+        echo "Release prepare for test module"
+        if [[ "${{ inputs.tests_module_type }}" == "mvn"  &&  "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
+          cd ${{ inputs.tests_module_path }}
+          mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
+        fi
 
     - name: Cache local Maven repository
       uses: actions/cache@v3
@@ -138,7 +158,13 @@ runs:
 
     - name: Perform release
       shell: bash
-      run: mvn -B -s ${{ inputs.mvn_settings_filepath }} release:perform -Prelease-to-staging-repository
+      run: | 
+        mvn -B -s ${{ inputs.mvn_settings_filepath }} release:perform -Prelease-to-staging-repository
+        echo "Perform release for test module"
+        if [[ "${{ inputs.tests_module_type }}" == "mvn"  &&  "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
+          cd ${{ inputs.tests_module_path }}
+          mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=$TAG_VERSION release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
+        fi
 
     - name: Copy artifacts
       shell: bash

--- a/release/action.yml
+++ b/release/action.yml
@@ -127,10 +127,11 @@ runs:
           NEXT_REVISION=`expr $REVISION + 1`
           NEXT_DEVELOPMENT_VERSION="$MAJOR_VERSION.$MINOR_VERSION.$NEXT_REVISION"-SNAPSHOT
         fi
+        echo "FINAL_RELEASE_VERSION=${FINAL_RELEASE_VERSION}"
+        echo "NEXT_DEVELOPMENT_VERSION=${NEXT_DEVELOPMENT_VERSION}"
         if [[ "${{ inputs.tests_module_type }}" == "mvn" && "${{ steps.check_test_module_mvn.outputs.files_exists }}" == "true" ]]; then
           echo "Release prepare for test module"
           cd ${{ inputs.tests_module_path }}
-          # mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B release:prepare -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] [Tests module]"
           # We only want to generate one single tag (for both the module and the test module), thus not being able to use release:prepare
           # We need to update the version in the test module, then commit these changes.
           mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} -B release:update-versions -DdevelopmentVersion="$FINAL_RELEASE_VERSION"


### PR DESCRIPTION
For running our tests with the test module on nightly (or manual) execution, we need to use the test artifacts stored in nexus.

If its version is not kept in-sync with the actual module it's testing, it can easily become painful to maintain. This PR adds the same logic than the publish action but adapted for release.

Note: The NPM modules are not covered.

Important: The pom.xml file of the test module must include the scm section, otherwise it will try pushing to a non-existing repo.