### PR TITLE
TECH-1641: Dependency check fails because of artefact not found in maven repository

### DIFF
--- a/dependencies-check-java/action.yml
+++ b/dependencies-check-java/action.yml
@@ -41,7 +41,7 @@ runs:
       shell: bash
       if: ${{ env.BASE_POM_NOT_FOUND == 0 }}
       run: |
-        mvn -Dmaven.repo.local="~/.m2/repository" -f ${{ inputs.root_folder }}/base-pom.xml dependency:list -Dsort=true -DforceStdout -DincludeScope=runtime -DoutputFile=base-deps.txt --no-transfer-progress
+        mvn -Dmaven.repo.local="/home/runner/.m2/repository" -f ${{ inputs.root_folder }}/base-pom.xml dependency:list -Dsort=true -DforceStdout -DincludeScope=runtime -DoutputFile=base-deps.txt --no-transfer-progress
 
     - name: Restore dependencies from cache
       uses: actions/cache/restore@v3
@@ -54,7 +54,7 @@ runs:
       shell: bash
       if: ${{ env.BASE_POM_NOT_FOUND == 0 }}
       run: |
-        mvn -Dmaven.repo.local="~/.m2/repository" -f ${{ inputs.root_folder }}/pom.xml dependency:list -Dsort=true -DforceStdout -DincludeScope=runtime -DoutputFile=deps.txt --no-transfer-progress
+        mvn -Dmaven.repo.local="/home/runner/.m2/repository" -f ${{ inputs.root_folder }}/pom.xml dependency:list -Dsort=true -DforceStdout -DincludeScope=runtime -DoutputFile=deps.txt --no-transfer-progress
 
     - name: Get POM differences and push a comment
       shell: bash
@@ -115,7 +115,7 @@ runs:
     - name: Check licenses
       shell: bash
       run: |
-        mvn license:add-third-party -Dmaven.repo.local="~/.m2/repository" -DlinkOnly=true -Dlicense.includedScopes=runtime -Dlicense.excludedScopes=test,provided -Dlicense.excludedTypes=war,pom -Dlicense.excludedGroups="^org\.jahia\..*" -Dlicense.useMissingFile=true --no-transfer-progress
+        mvn license:add-third-party -Dmaven.repo.local="/home/runner/.m2/repository" -DlinkOnly=true -Dlicense.includedScopes=runtime -Dlicense.excludedScopes=test,provided -Dlicense.excludedTypes=war,pom -Dlicense.excludedGroups="^org\.jahia\..*" -Dlicense.useMissingFile=true --no-transfer-progress
         grep -Eiv "^List|^The project has no dependencies|.*Jahia|${ALLOWLIST}" ${{ inputs.root_folder }}/target/generated-sources/license/THIRD-PARTY.txt > bad-licenses.txt || true
         if [[ $(wc -l <bad-licenses.txt) -gt 0 && $(wc -w <bad-licenses.txt) -gt 0 ]]; then
           echo "LICENSE_DIFF_STATUS=1" >> $GITHUB_ENV

--- a/dependencies-check-java/action.yml
+++ b/dependencies-check-java/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: |
         echo "MVN_LOCAL_REPO=$(echo ~/.m2/repository)" >> $GITHUB_ENV
-        echo "Base local mvn repo set to: " $MVN_LOCAL_REPO
+        echo "Base local mvn repo set to: $MVN_LOCAL_REPO"
 
     - name: Get base POM
       shell: bash

--- a/dependencies-check-java/action.yml
+++ b/dependencies-check-java/action.yml
@@ -47,7 +47,7 @@ runs:
       uses: actions/cache/restore@v3
       if: ${{ env.BASE_POM_NOT_FOUND == 0 }}
       with:
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/*/pom.xml') }}
         path: ~/.m2/repository
 
     - name: Get dependencies from local POM

--- a/dependencies-check-java/action.yml
+++ b/dependencies-check-java/action.yml
@@ -17,6 +17,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set mvn local repo location
+      shell: bash
+      run: |
+        echo ~/.m2/repository >> $MVN_LOCAL_REPO
+        echo "Base local mvn repo set to: " $MVN_LOCAL_REPO
+
     - name: Get base POM
       shell: bash
       run: |
@@ -41,7 +47,7 @@ runs:
       shell: bash
       if: ${{ env.BASE_POM_NOT_FOUND == 0 }}
       run: |
-        mvn -Dmaven.repo.local="/home/runner/.m2/repository" -f ${{ inputs.root_folder }}/base-pom.xml dependency:list -Dsort=true -DforceStdout -DincludeScope=runtime -DoutputFile=base-deps.txt --no-transfer-progress
+        mvn -Dmaven.repo.local=${{ env.MVN_LOCAL_REPO }} -f ${{ inputs.root_folder }}/base-pom.xml dependency:list -Dsort=true -DforceStdout -DincludeScope=runtime -DoutputFile=base-deps.txt --no-transfer-progress
 
     - name: Restore dependencies from cache
       uses: actions/cache/restore@v3
@@ -54,7 +60,7 @@ runs:
       shell: bash
       if: ${{ env.BASE_POM_NOT_FOUND == 0 }}
       run: |
-        mvn -Dmaven.repo.local="/home/runner/.m2/repository" -f ${{ inputs.root_folder }}/pom.xml dependency:list -Dsort=true -DforceStdout -DincludeScope=runtime -DoutputFile=deps.txt --no-transfer-progress
+        mvn -Dmaven.repo.local=${{ env.MVN_LOCAL_REPO }} -f ${{ inputs.root_folder }}/pom.xml dependency:list -Dsort=true -DforceStdout -DincludeScope=runtime -DoutputFile=deps.txt --no-transfer-progress
 
     - name: Get POM differences and push a comment
       shell: bash
@@ -115,7 +121,7 @@ runs:
     - name: Check licenses
       shell: bash
       run: |
-        mvn license:add-third-party -Dmaven.repo.local="/home/runner/.m2/repository" -DlinkOnly=true -Dlicense.includedScopes=runtime -Dlicense.excludedScopes=test,provided -Dlicense.excludedTypes=war,pom -Dlicense.excludedGroups="^org\.jahia\..*" -Dlicense.useMissingFile=true --no-transfer-progress
+        mvn license:add-third-party -Dmaven.repo.local=${{ env.MVN_LOCAL_REPO }} -DlinkOnly=true -Dlicense.includedScopes=runtime -Dlicense.excludedScopes=test,provided -Dlicense.excludedTypes=war,pom -Dlicense.excludedGroups="^org\.jahia\..*" -Dlicense.useMissingFile=true --no-transfer-progress
         grep -Eiv "^List|^The project has no dependencies|.*Jahia|${ALLOWLIST}" ${{ inputs.root_folder }}/target/generated-sources/license/THIRD-PARTY.txt > bad-licenses.txt || true
         if [[ $(wc -l <bad-licenses.txt) -gt 0 && $(wc -w <bad-licenses.txt) -gt 0 ]]; then
           echo "LICENSE_DIFF_STATUS=1" >> $GITHUB_ENV

--- a/dependencies-check-java/action.yml
+++ b/dependencies-check-java/action.yml
@@ -47,7 +47,7 @@ runs:
       uses: actions/cache/restore@v3
       if: ${{ env.BASE_POM_NOT_FOUND == 0 }}
       with:
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/*/pom.xml') }}
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         path: ~/.m2/repository
 
     - name: Get dependencies from local POM

--- a/dependencies-check-java/action.yml
+++ b/dependencies-check-java/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Set mvn local repo location
       shell: bash
       run: |
-        echo ~/.m2/repository >> $MVN_LOCAL_REPO
+        echo "MVN_LOCAL_REPO=$(echo ~/.m2/repository)" >> $GITHUB_ENV
         echo "Base local mvn repo set to: " $MVN_LOCAL_REPO
 
     - name: Get base POM


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

https://jira.jahia.org/browse/TECH-1641

## Description

Fix a problem in the maven cache management during dependency check phase for jahia-core.
The bug only occurs when a new maven artefact is included in the core and used in another core part.
By the way the cause affect the whole cache usage in dependency check.

## Tests

## Checklist

I have considered the following implications of my change: 

- [X] Performance

## Documentation
