### PR TITLE
TECH-1635 Make it possible to specify Yarn versions for static analysis action

### DIFF
--- a/static-analysis/action.yml
+++ b/static-analysis/action.yml
@@ -23,6 +23,12 @@ inputs:
   node_version:
     description: 'Version of node to install on the host'
     default: 'lts/*'
+  yarn_version:
+    description: 'Version of Yarn to use for module'
+    required: false
+  yarn_test_version:
+    description: 'Version of Yarn to use for tests in module'
+    required: false
   skip_lint_modules:
     description: skip linter for modules when set to true
     type: boolean
@@ -54,6 +60,9 @@ runs:
         echo "::group::Run yarn if package.json exists in module folder: ${{ inputs.module_path }}"
         if [[ -d "${{ inputs.module_path }}" && -e "${{ inputs.module_path }}package.json" ]]; then
           cd ${{ inputs.module_path }}
+          if [[ -n "${{ inputs.yarn_version }}" ]]; then
+            yarn set version ${{ inputs.yarn_version }}
+          fi
           yarn
         fi
         echo "::endgroup::"
@@ -63,6 +72,9 @@ runs:
         echo "::group::Run yarn if package.json exists in tests folder: ${{ inputs.tests_path }}"
         if [[ -d "${{ inputs.tests_path }}" && -e "${{ inputs.tests_path }}package.json" ]]; then
           cd ${{ inputs.tests_path }}
+          if [[ -n "${{ inputs.yarn_tests_version }}" ]]; then
+            yarn set version ${{ inputs.yarn_tests_version }}
+          fi
           yarn
         fi
         echo "::endgroup::"


### PR DESCRIPTION



<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-1635

## Description

- Two new inputs are added on the static-analysis action: yarn_version and yarn_tests_version
- If not specified the action will perform as before
- If specified they will be used like this : if [[ -n "${{ inputs.yarn_version }}" ]]; then yarn set version ${{ inputs.yarn_version }} fi

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

