### PR TITLE
INFRA-2967: Use fork for SBOM upload until ECONNRESET issue is fixed

### DIFF
--- a/sbom-processing/action.yml
+++ b/sbom-processing/action.yml
@@ -58,7 +58,7 @@ runs:
     # Using a fork until: https://github.com/DependencyTrack/gh-upload-sbom/pull/35 is merged
     # This fixes the issue faced with INFRA-2967
     - name: Upload sbom to Dependency Track
-      uses: entigolabs/gh-upload-sbom@master
+      uses: Jahia/gh-upload-sbom@master
       with:
           bomfilename: sbom-all.cdx.json
           serverhostname: ${{ inputs.dependencytrack_hostname }}

--- a/sbom-processing/action.yml
+++ b/sbom-processing/action.yml
@@ -54,9 +54,11 @@ runs:
       shell: bash
       run: |
         echo "::notice title=Dependency Track location::SBOM has been uploaded to: https://${{ inputs.dependencytrack_hostname }} Project name: ${{ inputs.dependencytrack_projectname }} version: ${{ inputs.dependencytrack_projectversion }}"
-          
+    
+    # Using a fork until: https://github.com/DependencyTrack/gh-upload-sbom/pull/35 is merged
+    # This fixes the issue faced with INFRA-2967
     - name: Upload sbom to Dependency Track
-      uses: DependencyTrack/gh-upload-sbom@v1.0.0
+      uses: entigolabs/gh-upload-sbom@master
       with:
           bomfilename: sbom-all.cdx.json
           serverhostname: ${{ inputs.dependencytrack_hostname }}


### PR DESCRIPTION
https://support.jahia.com/browse/INFRA-2967

Trying out the fix here: https://github.com/Jahia/remotepublish/actions/runs/10450275325