### PR TITLE
INFRA-2967: Switch to latest gh-upload-sbom release

### DIFF
--- a/sbom-processing/action.yml
+++ b/sbom-processing/action.yml
@@ -55,10 +55,8 @@ runs:
       run: |
         echo "::notice title=Dependency Track location::SBOM has been uploaded to: https://${{ inputs.dependencytrack_hostname }} Project name: ${{ inputs.dependencytrack_projectname }} version: ${{ inputs.dependencytrack_projectversion }}"
     
-    # Using a fork until: https://github.com/DependencyTrack/gh-upload-sbom/pull/35 is merged
-    # This fixes the issue faced with INFRA-2967
     - name: Upload sbom to Dependency Track
-      uses: Jahia/gh-upload-sbom@master
+      uses: DependencyTrack/gh-upload-sbom@v3.1.0
       with:
           bomfilename: sbom-all.cdx.json
           serverhostname: ${{ inputs.dependencytrack_hostname }}


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/INFRA-2967

## Description

Switch to latest gh-upload-sbom release and remove temporary comments

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
