### PR TITLE
BACKLOG-23224: Use .jahia.snapshot flag in package.json for NPM modules

### DIFF
--- a/build-step-npm/action.yml
+++ b/build-step-npm/action.yml
@@ -39,7 +39,14 @@ runs:
         MODULE_NAME="${MODULE_NAME////-}"
         echo "MODULE_NAME=$MODULE_NAME" >> $GITHUB_ENV
         MODULE_VERSION=$(jq '.version' package.json | cut -d\" -f2 )
-        if [[ $MODULE_VERSION == *-SNAPSHOT ]]; then
+        IS_SNAPSHOT=$(jq '.jahia.snapshot' package.json | cut -d\" -f2 )
+        echo "IS_SNAPSHOT=$IS_SNAPSHOT" >> $GITHUB_ENV
+        if [[ $IS_SNAPSHOT == true ]]; then
+          echo "MODULE_OLD_VERSION=${MODULE_VERSION%%-SNAPSHOT}" >> $GITHUB_ENV
+          echo "MODULE_VERSION=${MODULE_VERSION%%-SNAPSHOT}-SNAPSHOT" >> $GITHUB_ENV
+          echo "MODULE_OLD_VERSION=${MODULE_OLD_VERSION}" 
+          echo "MODULE_VERSION=${MODULE_VERSION}"
+        elif [[ $MODULE_VERSION == *-SNAPSHOT ]]; then
           echo "MODULE_VERSION=$MODULE_VERSION" >> $GITHUB_ENV
         else
           echo "MODULE_OLD_VERSION=$MODULE_VERSION" >> $GITHUB_ENV

--- a/build-step-npm/action.yml
+++ b/build-step-npm/action.yml
@@ -46,6 +46,8 @@ runs:
           echo "MODULE_VERSION=${MODULE_VERSION%%-SNAPSHOT}-SNAPSHOT" >> $GITHUB_ENV
           echo "MODULE_OLD_VERSION=${MODULE_OLD_VERSION}" 
           echo "MODULE_VERSION=${MODULE_VERSION}"
+        elif [[ $IS_SNAPSHOT == false ]]; then
+          echo "MODULE_VERSION=${MODULE_VERSION}" >> $GITHUB_ENV
         elif [[ $MODULE_VERSION == *-SNAPSHOT ]]; then
           echo "MODULE_VERSION=$MODULE_VERSION" >> $GITHUB_ENV
         else

--- a/release-npm/action.yml
+++ b/release-npm/action.yml
@@ -147,21 +147,12 @@ runs:
         fi
         echo "MODULE_VERSION=$(jq '.version' package.json | cut -d\" -f2)" >> $GITHUB_ENV
 
-    - name: Prepare the module
-      shell: bash
-      run: |
-        cd ${{ inputs.module_path }}
-        yarn
-    - name: Build the module
-      shell: bash
-      run: |
-        cd ${{ inputs.module_path }}
-        yarn build
-    - name: Package the module
-      shell: bash
-      run: |
-        cd ${{ inputs.module_path }}
-        yarn jahia-pack
+    - name: Build package
+      uses: jahia/jahia-modules-action/build-step-npm@v2
+      with:
+        module_path: ${{ inputs.module_path }}
+        node_version: ${{ inputs.node_version }}
+        github_artifact_retention: ${{ inputs.github_artifact_retention }}
 
     - name: Update github release for id ${{ inputs.release_id }}
       shell: bash
@@ -180,23 +171,7 @@ runs:
 
     - name: Perform release
       shell: bash
-      run: mvn -s ${{ inputs.mvn_settings_filepath }} deploy:deploy-file -Dfile=${{ inputs.module_path }}${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz -DgroupId=${{ env.GROUP_ID }} -DartifactId=${{ env.MODULE_NAME }} -Dversion=${{ env.MODULE_VERSION }} -Dpackaging=tgz -Durl=${{ env.REPOSITORY_URL }} -DrepositoryId=${{ env.REPOSITORY_ID }}
-
-    - name: Copy artifacts
-      shell: bash
-      run: |
-        mkdir /tmp/artifacts/
-        cd ${{ inputs.module_path }}
-        find . -name "*.tgz" -type f  -maxdepth 3 -mindepth 3 -exec cp {} /tmp/artifacts/ \;
-
-    - name: Release Artifacts
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: release-artifacts
-        path: |
-          /tmp/artifacts/
-        retention-days: ${{ inputs.github_artifact_retention }}
+      run: mvn -s ${{ inputs.mvn_settings_filepath }} deploy:deploy-file -Dfile=${{ inputs.module_path }}target/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz -DgroupId=${{ env.GROUP_ID }} -DartifactId=${{ env.MODULE_NAME }} -Dversion=${{ env.MODULE_VERSION }} -Dpackaging=tgz -Durl=${{ env.REPOSITORY_URL }} -DrepositoryId=${{ env.REPOSITORY_ID }}
 
     - name: set next development version into package.json
       shell: bash
@@ -211,7 +186,6 @@ runs:
         git add package.json
         git commit -m "[skip ci] prepare for next development iteration"
         git push
-
 
     - name: Post to a Slack channel
       if: ${{ inputs.slack-webhook-qa }}

--- a/release-npm/action.yml
+++ b/release-npm/action.yml
@@ -129,12 +129,15 @@ runs:
     - name: Update package.json
       shell: bash
       run: |
-        # Update package.json to match version precised in release tag
         cd ${{ inputs.module_path }}
+        # Update package.json to match version precised in release tag
         jq '.version |= "${{ env.FINAL_RELEASE_VERSION }}"' package.json > txt.json && jq '.' txt.json > package.json && rm txt.json
+        # Disable snapshot mode
+        jq '.jahia.snapshot |= false' package.json > txt.json && jq '.' txt.json > package.json && rm txt.json
 
-        if [ ! ${{ env.FINAL_RELEASE_VERSION }} -eq ${{ env.MODULE_VERSION }} ]
-        then
+        # Commit package.json if there are changes
+        if [[ -n "$(git diff --name-only package.json)" ]]; then
+          echo "Commit and push changes to package.json"
           git config user.name ${{ inputs.github_user_name }}
           git config user.email ${{ inputs.github_user_email }}
           git remote set-url origin https://x-access-token:${{ inputs.github_api_token }}@github.com/${{ inputs.github_slug}}
@@ -198,9 +201,11 @@ runs:
     - name: set next development version into package.json
       shell: bash
       run: |
-        # Update package.json to match next development version
         cd ${{ inputs.module_path }}
+        # Update package.json to match next development version
         jq '.version |= "${{ env.NEXT_DEVELOPMENT_VERSION }}"' package.json > txt.json && jq '.' txt.json > package.json && rm txt.json
+        # Enable snapshot mode
+        jq '.jahia.snapshot |= true' package.json > txt.json && jq '.' txt.json > package.json && rm txt.json
         git config user.name ${{ inputs.github_user_name }}
         git config user.email ${{ inputs.github_user_email }}
         git add package.json


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23224

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Use the `.jahia.snapshot` flag defined in the `package.json` file of our NPM modules to build and release.
In particular, when releasing a module, ensure the flag is disabled (as part of the "prepare release" commit) so the released artifact is not in snapshot mode, and re-renable the flag after releasing (as part of the "prepare for next development iteration" commit).
Also, fix the issue in the "SBOM processing" phase of the release workflow (see [this error in the release of luxe-jahia-demo:0.3.0](https://github.com/Jahia/luxe-jahia-demo/actions/runs/10384734159/job/28752445002)): delegate the build to `build-step-npm` that uploads the SBOM artifact, which can then be downloaded in the "SBOM processing" phase.