### PR TITLE
BACKLOG-23333: Move the .tgz to dist/ folder

### DIFF
--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -22,7 +22,7 @@ runs:
   using: 'composite'
   steps:
     - name: Build package
-      uses: jahia/jahia-modules-action/build-step-npm@v2
+      uses: jahia/jahia-modules-action/build-step-npm@BACKLOG-23333-move-to-dist-folder
       with:
         module_path: ${{ inputs.module_path }}
         node_version: ${{ inputs.node_version }}

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -22,7 +22,7 @@ runs:
   using: 'composite'
   steps:
     - name: Build package
-      uses: jahia/jahia-modules-action/build-step-npm@BACKLOG-23333-move-to-dist-folder
+      uses: jahia/jahia-modules-action/build-step-npm@v2
       with:
         module_path: ${{ inputs.module_path }}
         node_version: ${{ inputs.node_version }}

--- a/build-step-npm/action.yml
+++ b/build-step-npm/action.yml
@@ -80,12 +80,17 @@ runs:
       run: |
         # We move the .tgz to /target to ease CI manipulation inherited from maven structure
         cd ${{ inputs.module_path }}
-        if [ ! -e ${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz ]; then
-          mv ${{ env.MODULE_NAME }}-v${{ env.MODULE_OLD_VERSION }}.tgz ${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz
+        if [ -e dist/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz ]; then
+          mkdir -p target
+          mv dist/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz target/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz
+        else
+          # Fallback to the old behaviour
+          if [ ! -e ${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz ]; then
+            mv ${{ env.MODULE_NAME }}-v${{ env.MODULE_OLD_VERSION }}.tgz ${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz
+          fi
+          mkdir target
+          mv ${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz target/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz
         fi
-        mkdir target
-        mv ${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz target/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz
-
     - name: Archive build artifacts
       if: ${{ inputs.archive_artifacts == 'true' }}
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23333

## Description

Update the CI to get the .tgz file from the `dist/` folder since https://github.com/Jahia/javascript-components/pull/279.
In case there is no .tgz file in the `dist/` folder, fallback to the old behaviour to smoothly release this change. Eventually the _else_ condition should be removed once all Javascript projects use the "new" build tooling (that generates the file in the `dist/` folder).

Tested on Luxe in https://github.com/Jahia/luxe-jahia-demo/actions/runs/11743948367 (by forcing this branch to be used for the Github action).
