### PR TITLE
Renamed chores workflows

### DIFF
--- a/.github/workflows/issue-chores.yml
+++ b/.github/workflows/issue-chores.yml
@@ -1,5 +1,6 @@
-# This workflow performs various tasks for cleanup, triage, ... on GitHub Issues
-name: Issues Chores
+# This workflow performs various tasks for cleanup, triage, ... on an individual GitHub Issue
+# It should be called based on issue events
+name: Issue Chores
 
 on:
   workflow_call:

--- a/.github/workflows/pr-chores.yml
+++ b/.github/workflows/pr-chores.yml
@@ -1,5 +1,6 @@
-# This workflow performs various tasks for cleanup, triage, ... on GitHub PRs
-name: PRs Chores
+# This workflow performs various tasks for cleanup, triage, ... on an individual GitHub PR
+# It should be called based on PR events
+name: PR Chores
 
 on:
   workflow_call:


### PR DESCRIPTION
The previous naming was confusing and could give the impression that the workflows were performing operations on multiple issues or multiple PRs