### PR TITLE
fix: updated the projects job to also capture change of issue type

### DIFF
--- a/.github/workflows/delivery-issue-chores.yml
+++ b/.github/workflows/delivery-issue-chores.yml
@@ -167,7 +167,7 @@ jobs:
           router: delete:deleted-issues     
 
       # Transfer issues between repositories of the Jahia org
-      - name: Transfer Issue & Create Stub
+      - name: Transfer Issue to another repository
         uses: Fgerthoffert/actions-transfer-issue@v1.0.0
         if: ${{ github.event.action == 'labeled' }}
         with:

--- a/.github/workflows/delivery-issue-chores.yml
+++ b/.github/workflows/delivery-issue-chores.yml
@@ -172,7 +172,6 @@ jobs:
         if: ${{ github.event.action == 'labeled' }}
         with:
           token: ${{ secrets.GH_ISSUES_PRS_CHORES }}        
-          router: "transfer:"
           allow_private_public_transfer: true
 
   links:

--- a/.github/workflows/delivery-issue-chores.yml
+++ b/.github/workflows/delivery-issue-chores.yml
@@ -29,7 +29,7 @@ jobs:
 
   projects-label:
     name: Projects on Labels
-    if: ${{ github.event.action == 'labeled' }}
+    if: ${{ github.event.action == 'labeled' || github.event.action == 'typed' }}
     runs-on: ubuntu-latest
     steps:
       # Issue type is not available by default, this makes it available for if conditions


### PR DESCRIPTION
If a user decides to change an issue type, for example from Task to Epic, and if this issue has the right label, it might be necessary to add the issue to one of the projects.
