### PR TITLE
chore: updated version of the create-jira-link action

### DIFF
--- a/.github/workflows/reusable-delivery-issue-chores.yml
+++ b/.github/workflows/reusable-delivery-issue-chores.yml
@@ -184,7 +184,7 @@ jobs:
       # Create links in Jira to GitHub Issues
       # We still need to create a Jira User and update the server_host
       - name: Create links to GitHub in Jira issues
-        uses: Fgerthoffert/actions-create-jira-link@v1.0.0
+        uses: Fgerthoffert/actions-create-jira-link@v1.2.0
         if: steps.issue-exists.outputs.issue_number != ''
         with:
           token: ${{ secrets.GH_ISSUES_PRS_CHORES }}


### PR DESCRIPTION
The previous action was first verifying credentials (GitHub and Jira) before trying to determine jira keys based on the content of the issue.

This new version only initiates the connection to Jira (first to verify credentials) once it confirmed jira keys are indeed present.