### PR TITLE
fix: prevent failure if the issue state is not defined

### DIFF
--- a/delivery/keep-issue-open/action.yml
+++ b/delivery/keep-issue-open/action.yml
@@ -77,6 +77,13 @@ runs:
           }
 
           const githubIssue = githubIssueNode.node
+
+          if (githubIssue.state === undefined) {
+            core.info(`This does not appears to be a GitHub Issue`)
+            core.debug(JSON.stringify(githubIssue))
+            return
+          }
+
           core.info(`Issue with ID: ${githubIssueId} has status: ${githubIssue.state}`)
 
           if (githubIssue.state === "OPEN") {


### PR DESCRIPTION
This should prevent this from happening:
```
Run jahia/jahia-modules-action/delivery/keep-issue-open@v2
Run actions/github-script@v[7](https://github.com/Jahia/jexperience/actions/runs/12679913924/job/35340633257#step:3:8)
Issue with ID: PR_kwDOAT8V4s6HFz-V has status: undefined
TypeError: Cannot read properties of undefined (reading 'nodes')
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35424:16), <anonymous>:55:46)
    at async main (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35522:20)
Error: Unhandled error: TypeError: Cannot read properties of undefined (reading 'nodes')
```

https://github.com/Jahia/jexperience/actions/runs/12679913924/job/35340633257