### PR TITLE
 PIPELINE-109: Remove unused testrail parameter and add logging for testrail API call

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.module_branch }}
-      - uses: jahia/jahia-modules-action/integration-tests@v2
+      - uses: jahia/jahia-modules-action/integration-tests@fix-testrail-skip-flag
         with:
           module_id: ${{ inputs.module_id }}
           incident_service: ${{ inputs.pagerduty_incident_service }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.module_branch }}
-      - uses: jahia/jahia-modules-action/integration-tests@fix-testrail-skip-flag
+      - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
           module_id: ${{ inputs.module_id }}
           incident_service: ${{ inputs.pagerduty_incident_service }}

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -8,7 +8,6 @@ This is a regular typescript project, after checkout of the codebase:
 
 ```bash
 # Install all the dependencies
-yarn set version stable
 yarn
 ```
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -28,7 +28,7 @@ NODE_OPTIONS=--openssl-legacy-provider yarn run package
 # Fix issue with child.spawn
 We are currently waiting for both https://github.com/actions/toolkit/issues/1534 and https://github.com/actions/toolkit/pull/1469 to be included into the action toolkit to support step cancellation.
 
-In the meantime, after building/packaging, modity the `dist/index.js` search for `_getSpawnOptions(options, toolPath)` and update it as follow (simply adding the signal option):
+In the meantime, after building/packaging, modify the `dist/index.js` search for `_getSpawnOptions(options, toolPath)` and update it as follow (simply adding the signal option):
 
 Before:
 ```

--- a/integration-tests/src/jahia-reporter/testrail.ts
+++ b/integration-tests/src/jahia-reporter/testrail.ts
@@ -108,7 +108,7 @@ export async function publishToTestrail(
     command += ` --testrailCustomResultFields="${metadataFile}"`
     command += ` --linkRunFile="${testrailLinkFile}"`
   
-    await runShellCommands([command], 'artifacts/results/testrail.log', {printCmd: false})
+    await runShellCommands([command], null, {printCmd: false})
 
     if (fs.statSync(testrailLinkFile).isFile()) {
       const rawFile = fs.readFileSync(testrailLinkFile, 'utf8')

--- a/integration-tests/src/jahia-reporter/testrail.ts
+++ b/integration-tests/src/jahia-reporter/testrail.ts
@@ -108,7 +108,7 @@ export async function publishToTestrail(
     command += ` --testrailCustomResultFields="${metadataFile}"`
     command += ` --linkRunFile="${testrailLinkFile}"`
   
-    await runShellCommands([command], null, {printCmd: false})
+    await runShellCommands([command], 'artifacts/results/testrail.log', {printCmd: false})
 
     if (fs.statSync(testrailLinkFile).isFile()) {
       const rawFile = fs.readFileSync(testrailLinkFile, 'utf8')

--- a/integration-tests/src/main.ts
+++ b/integration-tests/src/main.ts
@@ -248,8 +248,7 @@ async function run(): Promise<void> {
     // Publish to testrail into Jahia-CI project
     if (
       core.getInput('should_skip_testrail') === 'false' ||
-      core.getInput('primary_release_branch') === process.env.CURRENT_BRANCH ||
-      core.getInput('should_skip_jahiaCIreporting') !== 'true'
+      core.getInput('primary_release_branch') === process.env.CURRENT_BRANCH
     ) {
       await core.group(
         `${timeSinceStart(startTime)} 🛠️ Publishing results to Testrail project: Jahia-CI}`,


### PR DESCRIPTION
https://jira.jahia.org/browse/PIPELINE-109
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Remove the unused parameter `should_skip_jahiaCIreporting` that was supposed to skip the global Testrail reporting (to the _JahiaCI_ project) but [was never set](https://github.com/search?q=org%3AJahia%20should_skip_jahiaCIreporting&type=code).
Thus that task was always running, even for PRs builds.

~~Also, collect the commands outputs (stdout and stderr) from the API calls to Testrail in the logfile `artifacts/results/testrail.log`.~~ --> idea got dropped as credentials would be leaked in the log in this case (as the executed command is present in the log file as it seems to be because of a low-level library).

Lastly, remove from the README the command upgrading Yarn (`yarn set version stable`) as this is causing the use of Yarn 4.6.x that leads to a different output build.