### PR TITLE
ci(npm): Update bundling of NPM modules

### DIFF
--- a/build-step-npm/action.yml
+++ b/build-step-npm/action.yml
@@ -69,18 +69,15 @@ runs:
         cmd: build
         dir: ${{ inputs.module_path }}
 
-    - name: Package the module
-      uses: borales/actions-yarn@v5
-      with:
-        cmd: jahia-pack
-        dir: ${{ inputs.module_path }}
-
     - name: Rename build file if necessary and move to /target
       shell: bash
       run: |
         # We move the .tgz to /target to ease CI manipulation inherited from maven structure
         cd ${{ inputs.module_path }}
-        if [ -e dist/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz ]; then
+        if [ -e dist/package.tgz ]; then
+          mkdir -p target
+          mv dist/package.tgz target/
+        elif [ -e dist/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz ]; then
           mkdir -p target
           mv dist/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz target/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz
         else


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Update the the building of NPM modules to use `dist/package.tgz` for the file path of the generated tgz file.
If not found, use the previous location (`dist/<<project>>-v<<version>>.tgz`).

This change is needed to accommodate the changes in https://github.com/Jahia/javascript-modules/pull/44/files and https://github.com/Jahia/luxe-jahia-demo/pull/178 where the _@jahia/scripts_ is removed from the projects' dependencies and the packing is directly handled by a `yarn pack`.

Also remove the _"Package the module"_ step as it duplicates the [_"Build the module"_](https://github.com/Jahia/jahia-modules-action/compare/update-packing-in-npm-builds?expand=1#diff-4e55c9e14c9b10e4e717c27cb494bb4e506b1ebc4641d0d8df4cded6017d20ccR66) one, that already performs a `yarn build`.
