### PR TITLE
ci(npm): Rename package.tgz after packing

### DIFF
--- a/build-step-npm/action.yml
+++ b/build-step-npm/action.yml
@@ -75,8 +75,10 @@ runs:
         # We move the .tgz to /target to ease CI manipulation inherited from maven structure
         cd ${{ inputs.module_path }}
         if [ -e dist/package.tgz ]; then
+          # Rename and move the tgz to target/
           mkdir -p target
-          mv dist/package.tgz target/
+          mv dist/package.tgz target/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz
+          # TODO: Once all modules are using the new structure, we can remove the lines below
         elif [ -e dist/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz ]; then
           mkdir -p target
           mv dist/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz target/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz

--- a/publish-npm/action.yml
+++ b/publish-npm/action.yml
@@ -49,8 +49,13 @@ runs:
     - name: Publish to maven
       shell: bash
       run: |
+        if [ -e ${{ inputs.module_path }}/target/package.tgz ]; then
+          FILE_PARAM=${{ inputs.module_path }}${{ inputs.tests_module_path }}/target/package.tgz
+        else
+          FILE_PARAM=${{ inputs.module_path }}/target/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz
+        fi
         # Run mvn deploy with parameters got from the package.json
-        mvn -s ${{ inputs.mvn_settings_filepath }} deploy:deploy-file -Dfile=${{ inputs.module_path }}/target/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz -DgroupId=${{ env.GROUP_ID }} -DartifactId=${{ env.MODULE_NAME }} -Dversion=${{ env.MODULE_VERSION }} -Dpackaging=tgz -Durl=${{ env.REPOSITORY_URL }} -DrepositoryId=${{ env.REPOSITORY_ID }}
+        mvn -s ${{ inputs.mvn_settings_filepath }} deploy:deploy-file -Dfile=$FILE_PARAM -DgroupId=${{ env.GROUP_ID }} -DartifactId=${{ env.MODULE_NAME }} -Dversion=${{ env.MODULE_VERSION }} -Dpackaging=tgz -Durl=${{ env.REPOSITORY_URL }} -DrepositoryId=${{ env.REPOSITORY_ID }}
 
     - name: Check if test module is present (Only NPM test module is supported)
       id: check_test_module_npm
@@ -70,5 +75,11 @@ runs:
       if: ${{ steps.check_test_module_npm.outputs.files_exists == 'true' }}
       shell: bash
       run: |
+        if [ -e ${{ inputs.module_path }}${{ inputs.tests_module_path }}/target/package.tgz ]; then
+          FILE_PARAM=${{ inputs.module_path }}${{ inputs.tests_module_path }}/target/package.tgz
+        else
+          FILE_PARAM=${{ inputs.module_path }}${{ inputs.tests_module_path }}/target/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz
+        fi
+        echo "test file to deploy: $FILE_PARAM"
         # Run mvn deploy with parameters got from the package.json
-        mvn -s ${{ inputs.mvn_settings_filepath }} deploy:deploy-file -Dfile=${{ inputs.module_path }}${{ inputs.tests_module_path }}/target/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz -DgroupId=${{ env.GROUP_ID }} -DartifactId=${{ env.MODULE_NAME }} -Dversion=${{ env.MODULE_VERSION }} -Dpackaging=tgz -Durl=${{ env.REPOSITORY_URL }} -DrepositoryId=${{ env.REPOSITORY_ID }}
+        mvn -s ${{ inputs.mvn_settings_filepath }} deploy:deploy-file -Dfile=$FILE_PARAM -DgroupId=${{ env.GROUP_ID }} -DartifactId=${{ env.MODULE_NAME }} -Dversion=${{ env.MODULE_VERSION }} -Dpackaging=tgz -Durl=${{ env.REPOSITORY_URL }} -DrepositoryId=${{ env.REPOSITORY_ID }}

--- a/publish-npm/action.yml
+++ b/publish-npm/action.yml
@@ -49,13 +49,8 @@ runs:
     - name: Publish to maven
       shell: bash
       run: |
-        if [ -e ${{ inputs.module_path }}/target/package.tgz ]; then
-          FILE_PARAM=${{ inputs.module_path }}${{ inputs.tests_module_path }}/target/package.tgz
-        else
-          FILE_PARAM=${{ inputs.module_path }}/target/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz
-        fi
         # Run mvn deploy with parameters got from the package.json
-        mvn -s ${{ inputs.mvn_settings_filepath }} deploy:deploy-file -Dfile=$FILE_PARAM -DgroupId=${{ env.GROUP_ID }} -DartifactId=${{ env.MODULE_NAME }} -Dversion=${{ env.MODULE_VERSION }} -Dpackaging=tgz -Durl=${{ env.REPOSITORY_URL }} -DrepositoryId=${{ env.REPOSITORY_ID }}
+        mvn -s ${{ inputs.mvn_settings_filepath }} deploy:deploy-file -Dfile=${{ inputs.module_path }}/target/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz -DgroupId=${{ env.GROUP_ID }} -DartifactId=${{ env.MODULE_NAME }} -Dversion=${{ env.MODULE_VERSION }} -Dpackaging=tgz -Durl=${{ env.REPOSITORY_URL }} -DrepositoryId=${{ env.REPOSITORY_ID }}
 
     - name: Check if test module is present (Only NPM test module is supported)
       id: check_test_module_npm
@@ -75,11 +70,5 @@ runs:
       if: ${{ steps.check_test_module_npm.outputs.files_exists == 'true' }}
       shell: bash
       run: |
-        if [ -e ${{ inputs.module_path }}${{ inputs.tests_module_path }}/target/package.tgz ]; then
-          FILE_PARAM=${{ inputs.module_path }}${{ inputs.tests_module_path }}/target/package.tgz
-        else
-          FILE_PARAM=${{ inputs.module_path }}${{ inputs.tests_module_path }}/target/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz
-        fi
-        echo "test file to deploy: $FILE_PARAM"
         # Run mvn deploy with parameters got from the package.json
-        mvn -s ${{ inputs.mvn_settings_filepath }} deploy:deploy-file -Dfile=$FILE_PARAM -DgroupId=${{ env.GROUP_ID }} -DartifactId=${{ env.MODULE_NAME }} -Dversion=${{ env.MODULE_VERSION }} -Dpackaging=tgz -Durl=${{ env.REPOSITORY_URL }} -DrepositoryId=${{ env.REPOSITORY_ID }}
+        mvn -s ${{ inputs.mvn_settings_filepath }} deploy:deploy-file -Dfile=${{ inputs.module_path }}${{ inputs.tests_module_path }}/target/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz -DgroupId=${{ env.GROUP_ID }} -DartifactId=${{ env.MODULE_NAME }} -Dversion=${{ env.MODULE_VERSION }} -Dpackaging=tgz -Durl=${{ env.REPOSITORY_URL }} -DrepositoryId=${{ env.REPOSITORY_ID }}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

Once the NPM package has been bundled in `dist/package.tgz`, rename it to `<module name>-v<version>.tgz` and move it to `target/`, as the CI expects the generated files to follow those rules.
