### PR TITLE
fix: limit unnecessary github actions runs on issues chores

### DIFF
--- a/.github/workflows/reusable-delivery-issue-chores.yml
+++ b/.github/workflows/reusable-delivery-issue-chores.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   general:
     name: General Issue operations
+    if: ${{ github.event.sender.login != 'jahia-ci' }}
     runs-on: ubuntu-latest
     steps:
       - name: Displays details about the event
@@ -29,7 +30,7 @@ jobs:
 
   projects-label:
     name: Projects on Labels
-    if: ${{ github.event.action == 'labeled' || github.event.action == 'typed' }}
+    if: ${{ (github.event.action == 'labeled' || github.event.action == 'typed') && github.event.sender.login != 'jahia-ci' }}
     runs-on: ubuntu-latest
     steps:
       # Issue type is not available by default, this makes it available for if conditions
@@ -105,7 +106,7 @@ jobs:
 
   projects-milestone:
     name: Projects on Milestones
-    if: ${{ github.event.action == 'milestoned' || github.event.action == 'demilestoned' }}
+    if: ${{ (github.event.action == 'milestoned' || github.event.action == 'demilestoned') && github.event.sender.login != 'jahia-ci' }}
     runs-on: ubuntu-latest
     steps:
       # Adds or removes the "Product Releases" project if a milestone is added
@@ -120,7 +121,7 @@ jobs:
     name: Transfer
     runs-on: ubuntu-latest
     needs: [projects-label, projects-milestone]
-    if: always()
+    if: always() && github.event.sender.login != 'jahia-ci'
     steps:
       # Transfer issues with label "jahia-only" back to jahia-private
       - name: Transfer Issue & Create Stub
@@ -160,13 +161,13 @@ jobs:
         uses: lando/transfer-issue-action@v2
         with:
           token: ${{ secrets.GH_ISSUES_PRS_CHORES }}        
-          router: incident:ISMS-Product
+          router: incident:ISMS-Product+
 
   links:
     name: Links
     runs-on: ubuntu-latest
     needs: transfer
-    if: always()
+    if: always() && github.event.sender.login != 'jahia-ci'
     steps:
       # If the issue was moved to a different repository it will not be possible to attach links
       # In that case skip the link creation, which will be handled next time an event happens on the issue

--- a/.github/workflows/reusable-delivery-issue-chores.yml
+++ b/.github/workflows/reusable-delivery-issue-chores.yml
@@ -161,7 +161,7 @@ jobs:
         uses: lando/transfer-issue-action@v2
         with:
           token: ${{ secrets.GH_ISSUES_PRS_CHORES }}        
-          router: incident:ISMS-Product+
+          router: incident:ISMS-Product
 
   links:
     name: Links


### PR DESCRIPTION
Some of the jobs within an action do trigger secondary workflow runs.

For example, if a user adds the label "refresh", jahia-ci will remove it once the operation is performed, but its removal does trigger un unnecessary workflow run ("jahia-ci removing the label").

There shouldn't be a need for the issue chore workflow to be triggered by jahia-ci.