### PR TITLE
fix: rename JavaScript publication action

### DIFF
--- a/publish-javascript/action.yml
+++ b/publish-javascript/action.yml
@@ -1,4 +1,4 @@
-name: publish javascrip module to maven repository (nexus)
+name: publish JavaScript module to maven repository (nexus)
 
 inputs:
   mvn_settings_filepath:


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Rename the action from `publish-javascript-module-to-maven-repository` to  `publish-javascript` to match what's defined in the generic [`publish` action](https://github.com/Jahia/jahia-modules-action/blob/4f38a88bd8220a2d4f89f6835d61965febfd0dee/publish/action.yml#L81) and referenced by JavaScript projects (ex: https://github.com/Jahia/npm-templates-web-blue/blob/chore/rename-npm-to-javascript/.github/workflows/on-code-change.yml#L35).
Follows https://github.com/Jahia/jahia-modules-action/pull/205.