### PR TITLE
fix: Fixed creation of jira links following migration to JSM

### DIFF
--- a/.github/workflows/reusable-delivery-issue-chores.yml
+++ b/.github/workflows/reusable-delivery-issue-chores.yml
@@ -184,6 +184,7 @@ jobs:
         with:
           token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
           jira_server_host: support.jahia.com
+          jira_intermediate_path: /rest/api/2
           jira_server_username: ${{ secrets.JIRA_SUPPORT_USERNAME }}
           jira_server_password: ${{ secrets.JIRA_SUPPORT_PASSWORD }}
           github_project_field: "Jira tickets"


### PR DESCRIPTION
By default, the lib calling Jira is targetting the "agile" endpoints, that do not seem to be available with Jira JSM.

I verified locally that the operations for creating Jira links are still working with the rest API (not the Agile one we were using previously).