### PR TITLE
fix: Fixed creation of jira links following migration to JSM

### DIFF
--- a/.github/workflows/reusable-delivery-issue-chores.yml
+++ b/.github/workflows/reusable-delivery-issue-chores.yml
@@ -179,7 +179,7 @@ jobs:
       # Create links in Jira to GitHub Issues
       # We still need to create a Jira User and update the server_host
       - name: Create links to GitHub in Jira issues
-        uses: Fgerthoffert/actions-create-jira-link@v1.2.0
+        uses: Fgerthoffert/actions-create-jira-link@v1.3.0
         if: steps.issue-exists.outputs.issue_number != ''
         with:
           token: ${{ secrets.GH_ISSUES_PRS_CHORES }}


### PR DESCRIPTION
In the previous PR, I forgot to upgrade the version of the action