### PR TITLE
build: Setup .yarnrc.yml to support publication with 'yarn npm publish'

### DIFF
--- a/release/action.yml
+++ b/release/action.yml
@@ -81,6 +81,12 @@ runs:
         node-version: 'lts/*'
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Setup .yarnrc.yml file to allow publication to https://registry.npmjs.org with a 'yarn npm publish'
+      if: ${{ inputs.npmjs_publish_token != '' }}
+      shell: bash
+      run: |
+        echo "npmAuthToken: ${{ inputs.npmjs_publish_token }}" >> ~/.yarnrc.yml
+
     - name: Generate maven cache seed
       shell: bash
       run: |


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Store the NPM auth token in the `~/.yarnrc.yml` to allow publication of npm packages to https://registry.npmjs.org with a `yarn npm publish`.
This fixes the following error:
```
[INFO] [INFO] ➤ YN0033: No authentication configured for request
[INFO] [INFO] ➤ YN0000: Failed with errors in 0s 369ms
```
(See https://github.com/Jahia/javascript-modules/actions/runs/13546517850/job/37859375125 for full details).

Suggestion from https://github.com/actions/setup-node/issues/942#issuecomment-1920476219.