### PR TITLE
fix: Failed to parse NVD data

### DIFF
--- a/sonar-analysis/action.yml
+++ b/sonar-analysis/action.yml
@@ -130,7 +130,7 @@ runs:
           echo "Skipping OWASP for PR analysis"
         else
           echo "Executing an OWASP analysis on branch: ${{ inputs.primary_release_branch }}"
-          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.owasp:dependency-check-maven:10.0.3:aggregate \
+          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.owasp:dependency-check-maven:12.1.0:aggregate \
             $SONAR_PARAMS
         fi
 


### PR DESCRIPTION
## Description

Compatibility issues with the NVD API lead to failing nightly checks. Fix is to do the mandatory update of dependency-check-maven and follow advise on: https://github.com/dependency-check/DependencyCheck/issues/7463
