### PR TITLE
feat: Add the ability to release the action from GitHub UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ permissions:
 jobs:
   update_tag:
     name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
-    environment:
-      name: releaseNewActionVersion
     runs-on: ubuntu-latest
     steps:
       - name: Update the ${{ env.TAG_NAME }} tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,4 @@ jobs:
         with:
           source-tag: ${{ env.TAG_NAME }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL_RC_FOR_QA }}
+          token: ${{ secrets.GH_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,5 +23,5 @@ jobs:
         uses: actions/publish-action@v0.3.0
         with:
           source-tag: ${{ env.TAG_NAME }}
-          slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL_RC_FOR_QA }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK_RELEASE_NOTIFICATION }}
           token: ${{ secrets.GH_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,4 @@ jobs:
         uses: actions/publish-action@v0.3.0
         with:
           source-tag: ${{ env.TAG_NAME }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL_RC_FOR_QA }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release jahia-modules-action
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: 'Tag name that the major tag will point to'
+        required: true
+
+env:
+  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+permissions:
+  contents: write
+
+jobs:
+  update_tag:
+    name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
+    environment:
+      name: releaseNewActionVersion
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update the ${{ env.TAG_NAME }} tag
+        uses: actions/publish-action@v0.3.0
+        with:
+          source-tag: ${{ env.TAG_NAME }}

--- a/README.md
+++ b/README.md
@@ -36,15 +36,18 @@ For the dependencies checks, here's a blog post explaining how they've been buil
 
 ## Releasing the Action
 
-Since a large portion of our repositories are using the action, we're using a particular branch as an alias to the latest changes (`v1`, `v2`). Releasing consists in updating this branch with the changes you want to make available.
+IMPORTANT: Do not create `v2` branches anymore, this alias is now a Git tag, and is generated automatically
 
-To release changes, proceed as follow:
+To release the action, create a new release via the GitHub UI: https://github.com/Jahia/jahia-modules-action/releases
 
-- Create a tag, with your desired version (for example: `v2.1.0`).
-- Delete branch `v2`
-- Move into the tag `v2.1.0` and create a `v2` branch from that tag.
+Click on:
+- Draft a new release
+- Select a tag (please follow SemVer) using this pattern v2.5.6
+- Enter a title (the version number)
+- Select "Set as the latest release"
+- Click on Publish release
 
-Any runs triggered between the time the `v2` branch is deleted and re-created will FAIL. Deleting and creating a new branch shouldn't take more than a couple of seconds.
+If your version was v2.5.6, this will create two tags: v2.5.6 and v2
 
 ## Open-Source
 


### PR DESCRIPTION
As mentioned in the source issue, the release of the alias appears to be confusing.

With this change, we'll be able to release the action the same way we release modules and not have to worry about the creation of the alias.

This was tested here: https://github.com/Jahia/test-repo-action-release/actions/runs/13568032665/job/37925581656

A message will be automatically posted to #team-product-cicd when the tag is created.

This workflow is actually in use at GitHub, for example by the setup-node action: https://github.com/actions/setup-node/blob/main/.github/workflows/release-new-action-version.yml 
