### PR TITLE
ci(sbom): Include default dir of Rollup SB0M plugin

### DIFF
--- a/release/action.yml
+++ b/release/action.yml
@@ -252,6 +252,7 @@ runs:
         path: |
           **/target/java-bom*
           **/target/classes/javascript/**/bom/*
+          **/target/classes/javascript/cyclonedx/*
           !**/target/checkout/*
         retention-days: ${{ inputs.github_artifact_retention }}
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
When retrieving the SBOM artifacts, include the default output directory `cyclonedx` of the [Rollup plugin](https://github.com/janbiasi/rollup-plugin-sbom), that is now used by Vite's configuration of the [Javascript Modules Engine](https://github.com/Jahia/javascript-modules/blob/main/javascript-modules-engine/rollup.config.mjs#L34).

Directory structure of `javascript-modules-engine` after a build:
![image](https://github.com/user-attachments/assets/0aba2cca-dda6-4628-9d42-c1cf22eb762b)

Without it, the _SBOM processing_ step of the release fails (see [this example](https://github.com/Jahia/javascript-modules/actions/runs/13625915794/job/38084205392)).