### PR TITLE
fix: Corrected typo in issues workflow

### DIFF
--- a/.github/workflows/reusable-delivery-issue-chores.yml
+++ b/.github/workflows/reusable-delivery-issue-chores.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Create a Security Jira ticket for every new Epic
         uses: jahia/jahia-modules-action/delivery/create-security-ticket@v2
-        if: ${{ steps.get-issue.outputs.issue_type == 'Epic' && context.payload.action == 'opened' }}
+        if: ${{ steps.get-issue.outputs.issue_type == 'Epic' && github.event.action == 'opened' }}
         with:
           jira-username: ${{ secrets.JIRA_USERNAME }}
           jira-password: ${{ secrets.JIRA_PASSWORD }}


### PR DESCRIPTION
Aims at fixing this error:

```
[Invalid workflow file: .github/workflows/delivery-issue-chores.yml#L11](https://github.com/Jahia/jahia-private/actions/runs/13758966450/workflow)
The workflow is not valid. In .github/workflows/delivery-issue-chores.yml (Line: 11, Col: 11): Error from called workflow Jahia/jahia-modules-action/.github/workflows/reusable-delivery-issue-chores.yml@v2 (Line: 73, Col: 13): Unrecognized named-value: 'context'. Located at position 49 within expression: steps.get-issue.outputs.issue_type == 'Epic' && context.payload.action == 'opened'
```