### PR TITLE
fix: Archive artifacts in target/ recursively

### DIFF
--- a/build-step-mvn/action.yml
+++ b/build-step-mvn/action.yml
@@ -77,8 +77,7 @@ runs:
       with:
         name: ${{ inputs.github_artifact_name }}
         path: |
-          ${{ inputs.module_path }}target/*
-          ${{ inputs.module_path }}*/target/*
+          ${{ inputs.module_path }}**/target/*
           **/*source-release.zip
         retention-days: ${{ inputs.github_artifact_retention }}
 


### PR DESCRIPTION
### Description
Include artifacts in the `target/` folders, regardless of their depth level. Needed by https://github.com/Jahia/javascript-modules/pull/217.

This is for instance needed when a module is located in a sub-sub-directory (example [here](https://github.com/Jahia/javascript-modules/blob/refacto-tests-modules/samples/hydrogen/pom.xml)).
