### PR TITLE
fix: updated the transfer issue action to address an issue with participants

### DIFF
--- a/.github/workflows/reusable-delivery-issue-chores.yml
+++ b/.github/workflows/reusable-delivery-issue-chores.yml
@@ -168,7 +168,7 @@ jobs:
 
       # Transfer issues between repositories of the Jahia org
       - name: Transfer Issue to another repository
-        uses: Fgerthoffert/actions-transfer-issue@v1.1.0
+        uses: Fgerthoffert/actions-transfer-issue@v1.1.2
         if: ${{ github.event.action == 'labeled' }}
         with:
           token: ${{ secrets.GH_ISSUES_PRS_CHORES }}        


### PR DESCRIPTION
For some reason, participants count take longer to transfer, this was making the transfer check fail.

Updated to use the assignees count, which appears to be closer to the actual issue model.