### PR TITLE
fix: Fix missing/deprecated params

### DIFF
--- a/.github/workflows/reusable-integration-tests.yml
+++ b/.github/workflows/reusable-integration-tests.yml
@@ -59,9 +59,12 @@ on:
       artifact_prefix:
         type: string
         default: "tests"
+      # deprecated
       should_use_build_artifacts:
         type: boolean
+        required: false
         default: false
+        description: 'Should the job attempt to download previously built artifacts'
       should_skip_testrail:
         type: boolean
         default: false
@@ -113,7 +116,6 @@ jobs:
           jahia_cluster_enabled: ${{ inputs.jahia_cluster_enabled }}
           elasticsearch_image: ${{ inputs.elasticsearch_image }}
           jcustomer_image: ${{ inputs.jcustomer_image }}
-          should_use_build_artifacts: ${{ inputs.should_use_build_artifacts }}
           should_skip_testrail: ${{ inputs.should_skip_testrail }}
           should_skip_pagerduty: ${{ inputs.pagerduty_skip_notification }}
           github_artifact_name: ${{ inputs.artifact_prefix }}-${{ github.run_number }}

--- a/.github/workflows/reusable-sonar-scan.yml
+++ b/.github/workflows/reusable-sonar-scan.yml
@@ -21,6 +21,10 @@ on:
         type: string
         required: false
         default: "main"
+      github_slug:
+        type: string
+        description: 'GitHub SLUG of the module (for example: jahia/sandbox)'
+        required: true
       java_distribution:
         type: string
         required: false
@@ -34,7 +38,7 @@ on:
         required: false
         default: "mvn"
       incident_service:
-        type: string      
+        type: string
         description: 'Service subject to the incident. If empty, will default to the value of module_id'
         required: false
         default: ''
@@ -65,7 +69,7 @@ jobs:
           tests_module_type: ${{ inputs.tests_module_type }}
           mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}  
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
       - uses: jahia/jahia-modules-action/sonar-analysis@v2
         with:
           primary_release_branch: ${{ inputs.git_branch }}
@@ -77,6 +81,7 @@ jobs:
           mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+          github_slug: ${{ inputs.github_slug }}
       - id: status
         name: Prepare the status message for pagerduty
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.project
 *.iml
 .DS_Store
+.idea


### PR DESCRIPTION
### Description


- Add missing required `github_slug` in sonar action reusable workflow
- Remove deprecated param  `should_use_build_artifacts` in reusable integration test workflow (not sure if ok to fully remove that param or keep for now) 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
