### PR TITLE
ci(cache): Fix Maven cache for publish & release actions

### DIFF
--- a/publish/action.yml
+++ b/publish/action.yml
@@ -39,7 +39,9 @@ runs:
     - name: Cache local Maven repository
       uses: actions/cache@v4
       with:
-        path: ~/.m2/repository
+        path: |
+          ~/.m2/repository
+          /root/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-

--- a/release/action.yml
+++ b/release/action.yml
@@ -113,7 +113,9 @@ runs:
     - name: Cache local Maven repository
       uses: actions/cache@v4
       with:
-        path: ~/.m2/repository
+        path: |
+          ~/.m2/repository
+          /root/.m2/repository
         key: v1-maven-dependencies-${{ hashFiles('**/maven_cache_seed') }}
         restore-keys: |
           v1-maven-dependencies-${{ hashFiles('**/maven_cache_seed') }}


### PR DESCRIPTION
### Description
The Maven repository is not cached for the Publish and Release workflows in Github: the Docker containers are running with the root user which populates the `/root/.m2/repository` Maven repository. However, `~`, refers to the user running the Github Actions, which is not the root user.

Example in [this post run jahia/jahia-modules-action/publish@v2](https://github.com/Jahia/cloudimage/actions/runs/14472671763/job/40590750314): 
```
Post job cleanup.
/usr/bin/docker exec  6fbf54684523e0c08963e69c44d3b[1](https://github.com/Jahia/cloudimage/actions/runs/14472671763/job/40590750314#step:8:1)921942ee5ff069d199c4fc49f06300ff[2](https://github.com/Jahia/cloudimage/actions/runs/14472671763/job/40590750314#step:8:2)7 sh -c "cat /etc/*release | grep ^ID"
Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

Adding `/root/m2/repository` to the paths to be included when computing the key for the cache, similar to what is done in https://github.com/Jahia/jahia-modules-action/blob/main/build-step-mvn/action.yml#L49.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
