### PR TITLE
fix: Add default value for sonar input

### DIFF
--- a/.github/workflows/reusable-sonar-scan.yml
+++ b/.github/workflows/reusable-sonar-scan.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Set default values
         id: vars
         run: |
-          echo "Github repo slug: ${{ github.repository }}"
+          echo "GitHub repo slug: ${{ github.repository }}"
           echo "github_repo=${{ github.repository }}" >> $GITHUB_OUTPUT
       - uses: jahia/jahia-modules-action/sonar-analysis@v2
         with:

--- a/.github/workflows/reusable-sonar-scan.yml
+++ b/.github/workflows/reusable-sonar-scan.yml
@@ -24,7 +24,6 @@ on:
       github_slug:
         type: string
         description: 'GitHub SLUG of the module (for example: jahia/sandbox)'
-        required: true
       java_distribution:
         type: string
         required: false
@@ -70,6 +69,9 @@ jobs:
           mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+      - name: Set default values
+        id: vars
+        run: echo "github_repo=${{ github.repository }}" >> $GITHUB_OUTPUT
       - uses: jahia/jahia-modules-action/sonar-analysis@v2
         with:
           primary_release_branch: ${{ inputs.git_branch }}
@@ -81,7 +83,7 @@ jobs:
           mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          github_slug: ${{ inputs.github_slug }}
+          github_slug: ${{ inputs.github_slug || steps.vars.outputs.github_repo }}
       - id: status
         name: Prepare the status message for pagerduty
         if: always()

--- a/.github/workflows/reusable-sonar-scan.yml
+++ b/.github/workflows/reusable-sonar-scan.yml
@@ -71,7 +71,9 @@ jobs:
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
       - name: Set default values
         id: vars
-        run: echo "github_repo=${{ github.repository }}" >> $GITHUB_OUTPUT
+        run: |
+          echo "Github repo slug: ${{ github.repository }}"
+          echo "github_repo=${{ github.repository }}" >> $GITHUB_OUTPUT
       - uses: jahia/jahia-modules-action/sonar-analysis@v2
         with:
           primary_release_branch: ${{ inputs.git_branch }}

--- a/.github/workflows/reusable-sonar-scan.yml
+++ b/.github/workflows/reusable-sonar-scan.yml
@@ -69,11 +69,6 @@ jobs:
           mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-      - name: Set default values
-        id: vars
-        run: |
-          echo "GitHub repo slug: ${{ github.repository }}"
-          echo "github_repo=${{ github.repository }}" >> $GITHUB_OUTPUT
       - uses: jahia/jahia-modules-action/sonar-analysis@v2
         with:
           primary_release_branch: ${{ inputs.git_branch }}
@@ -85,7 +80,7 @@ jobs:
           mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          github_slug: ${{ inputs.github_slug || steps.vars.outputs.github_repo }}
+          github_slug: ${{ inputs.github_slug }}
       - id: status
         name: Prepare the status message for pagerduty
         if: always()

--- a/sonar-analysis/action.yml
+++ b/sonar-analysis/action.yml
@@ -8,7 +8,6 @@ inputs:
     default: main
   github_slug:
     description: 'GitHub SLUG of the module (for example: jahia/sandbox)'
-    required: true
   sonar_url:
     description: 'URL to the SONAR server'
     required: true
@@ -99,15 +98,18 @@ runs:
         restore-keys: |
           v3-sonar-owasp-dependencies-{{ checksum "is_pr" }}
 
-    - name: Extract branch name
-      shell: bash
-      run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
-      id: extract_branch
-
-    - name: Display branch name
+    - name: Setup Sonar env variables
       shell: bash
       run: |
-        echo "BRANCH: ${{ steps.extract_branch.outputs.branch }}"
+        echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+        echo "github_slug=${{ inputs.github_slug || github.repository }}" >> $GITHUB_OUTPUT
+      id: vars
+
+    - name: Display variable values
+      shell: bash
+      run: |
+        echo "BRANCH: ${{ steps.vars.outputs.branch }}"
+        echo "GITHUB_SLUG: ${{ steps.vars.outputs.github_slug }}"
         echo "GITHUB_REF: ${GITHUB_REF}"
 
     - name: Set common Sonar parameters
@@ -145,8 +147,8 @@ runs:
               -Dsonar.pullrequest.branch=$GITHUB_REF \
               -Dsonar.pullrequest.key=${{ inputs.github_pr_id }} \
               -Dsonar.pullrequest.base=${{ inputs.primary_release_branch }} \
-              -Dsonar.pullrequest.github.repository=${{ inputs.github_slug }}
-        elif [[ ${{ steps.extract_branch.outputs.branch }} == ${{ inputs.primary_release_branch }} ]]; then
+              -Dsonar.pullrequest.github.repository=${{ steps.vars.outputs.github_slug }}
+        elif [[ ${{ steps.vars.outputs.branch }} == ${{ inputs.primary_release_branch }} ]]; then
           echo "Executing an analysis on the main branch"
           mvn -B -s ${{ inputs.mvn_settings_filepath }} sonar:sonar \
             $SONAR_PARAMS


### PR DESCRIPTION
### Description

Causing some issues with runs because of the required status e.g. https://github.com/Jahia/graphql-core/actions/runs/14484473053

Will supply default slug in the action and remove required clause in both action and reusable workflow

- Added `steps.vars.outputs.github_slug` that defaults to `${{ github.repository }}` value if `inputs.github_slug` is not specified when calling the action.
- Existing output variable `steps.extract_branch.outputs.branch` renamed to `steps.**vars**.outputs.branch`

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
