### PR TITLE
ci!: Use "main" as default branch for int tests

### DIFF
--- a/.github/workflows/reusable-integration-tests.yml
+++ b/.github/workflows/reusable-integration-tests.yml
@@ -35,7 +35,7 @@ on:
       module_branch:
         required: false
         type: string
-        default: "master"
+        default: "main"
       provisioning_manifest:
         required: true
         type: string


### PR DESCRIPTION
### Description
Considering that `main` is now the default branch on Github and that most of our repositories use `main` rather than `master`, we could update the default value for the `module_branch` parameter, in order to reduce the number of parameters to pass to the _reusable-integration-tests_ workflow.


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
