### PR TITLE
chore: updated to actions-transfer-issue v1.3.0

### DIFF
--- a/.github/workflows/reusable-delivery-issue-chores.yml
+++ b/.github/workflows/reusable-delivery-issue-chores.yml
@@ -168,7 +168,7 @@ jobs:
 
       # Transfer issues between repositories of the Jahia org
       - name: Transfer Issue to another repository
-        uses: Fgerthoffert/actions-transfer-issue@v1.1.2
+        uses: Fgerthoffert/actions-transfer-issue@v1.3.0
         if: ${{ github.event.action == 'labeled' }}
         with:
           token: ${{ secrets.GH_ISSUES_PRS_CHORES }}        


### PR DESCRIPTION
This update should make the issue transfer workflow more robust and easier to debug in case of failure.
