### PR TITLE
feat: remove the CI job re-opening issues

### DIFF
--- a/.github/workflows/reusable-delivery-issue-chores.yml
+++ b/.github/workflows/reusable-delivery-issue-chores.yml
@@ -8,9 +8,9 @@ on:
   workflow_call:
 
 jobs:
-  general:
-    name: General Issue operations
-    if: ${{ github.event.sender.login != 'jahia-ci' }}
+  projects-label:
+    name: Projects on Labels
+    if: ${{ (github.event.action == 'labeled' || github.event.action == 'typed') && github.event.sender.login != 'jahia-ci' }}
     runs-on: ubuntu-latest
     steps:
       - name: Displays details about the event
@@ -23,18 +23,8 @@ jobs:
             core.info(`context.payload.issue.number: ${context.payload.issue.number}`)
             core.info(`context.payload.issue.html_url: ${context.payload.issue.html_url}`)
             core.info(`context.payload.sender.login: ${context.payload.sender.login}`)
-            core.debug(context)    
-      - name: Re-open issue closed and not in the Done column
-        uses: jahia/jahia-modules-action/delivery/keep-issue-open@v2
-        with:
-          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
-          project_prefix: "Product Team"
-
-  projects-label:
-    name: Projects on Labels
-    if: ${{ (github.event.action == 'labeled' || github.event.action == 'typed') && github.event.sender.login != 'jahia-ci' }}
-    runs-on: ubuntu-latest
-    steps:
+            core.debug(context)  
+    
       # Issue type is not available by default, this makes it available for if conditions
       - name: Get Issue type
         uses: jahia/jahia-modules-action/delivery/get-issue@v2


### PR DESCRIPTION
We previously had a workflow that was re-opening issues that were closed but not in the Done column. This was put in place to prevent issues from being closed automatically when an attached PR was closed as well.

GitHub finally introduced a feature to disable that behavior, closing a PR will not automatically close associated issues.
https://github.blog/changelog/2025-04-23-users-can-now-choose-whether-merging-linked-pull-requests-automatically-closes-the-issue/

The new setting was enabled on all Jahia product repositories, the workflow can now be removed.

Some notes:
 - I did not remove the actual action since it might be useful for other uses later.
 - I also removed entirely the "general" job. The last remaining step was only useful to display some debug details, I moved them to the projects-label job

