### PR TITLE
ci: Unable to extract URLs from Maven logs

### DIFF
--- a/publish/action.yml
+++ b/publish/action.yml
@@ -68,7 +68,7 @@ runs:
     - name: Direct link location of the Artifact
       shell: bash
       run: |
-        EXTRACTED_NEXUS_ARTIFACT_URL=`grep -e "Uploaded.*\.jar" mvnLogs.txt | grep -v sources | sed -e 's/.*\(https.*.jar\).*/\1/g'`
+        EXTRACTED_NEXUS_ARTIFACT_URL=`grep --text -e "Uploaded.*\.jar" mvnLogs.txt | grep -v sources | sed -e 's/.*\(https.*.jar\).*/\1/g'`
         echo "::notice title=Snapshot module location::Artifact has been uploaded to: $EXTRACTED_NEXUS_ARTIFACT_URL"
 
     - name: Check if test module is present (Javascript)

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -50,6 +50,12 @@ runs:
       shell: bash
       run: mvn -B -s ${{ inputs.mvn_settings_filepath }} clean deploy -DskipTests -Dmaven.resolver.transport=wagon | tee mvnLogs.txt
 
+    - name: Direct link location of the Artifact
+      shell: bash
+      run: |
+        EXTRACTED_NEXUS_ARTIFACT_URL=`grep --text -e "Uploaded.*\.jar" mvnLogs.txt | grep -v sources | sed -e 's/.*\(https.*.jar\).*/\1/g'`
+        echo "::notice title=Snapshot module location::Artifact has been uploaded to: $EXTRACTED_NEXUS_ARTIFACT_URL"
+
     - name: Check if test module is present (MVN)
       if: ${{ inputs.tests_module_type == 'mvn' }}
       id: check_test_module_mvn
@@ -64,12 +70,6 @@ runs:
         ROOT_PATH=$(pwd)
         cd ${{ inputs.tests_module_path }}
         mvn -B -U -ntp -s $ROOT_PATH/${{ inputs.mvn_settings_filepath }} clean deploy -DskipTests -Dmaven.resolver.transport=wagon
-
-    - name: Direct link location of the Artifact
-      shell: bash
-      run: |
-        EXTRACTED_NEXUS_ARTIFACT_URL=`grep --text -e "Uploaded.*\.jar" mvnLogs.txt | grep -v sources | sed -e 's/.*\(https.*.jar\).*/\1/g'`
-        echo "::notice title=Snapshot module location::Artifact has been uploaded to: $EXTRACTED_NEXUS_ARTIFACT_URL"
 
     - name: Check if test module is present (Javascript)
       if: ${{ inputs.tests_module_type == 'javascript' }}


### PR DESCRIPTION
### Description
The _publish module_ step of the _On merge to main_ workflow has been failing for the [Javascript Modules repository](https://github.com/Jahia/javascript-modules/actions/workflows/on-merge.yml) with the following error ([example of a run that failed](https://github.com/Jahia/javascript-modules/actions/runs/14834286594/job/41643407422)):
```
Run EXTRACTED_NEXUS_ARTIFACT_URL=`grep -e "Uploaded.*\.jar" mvnLogs.txt | grep -v sources | sed -e 's/.*\(https.*.jar\).*/\1/g'`
grep: mvnLogs.txt: binary file matches
Error: Process completed with exit code 1.
```

However, the warning `grep: mvnLogs.txt: binary file matches` has been present for a while, and was not causing the workflow to fail (this [successful run](https://github.com/Jahia/javascript-modules/actions/runs/14833993968/job/41642569577) for instance). So not sure if this will actually fix the issue...

It's not clear why the workflow suddenly failed.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
