### PR TITLE
fix: removed uploading CHANGELOG.md

### DIFF
--- a/release-javascript/action.yml
+++ b/release-javascript/action.yml
@@ -154,21 +154,6 @@ runs:
         node_version: ${{ inputs.node_version }}
         github_artifact_retention: ${{ inputs.github_artifact_retention }}
 
-    - name: Update github release for id ${{ inputs.release_id }}
-      shell: bash
-      run: |
-        echo "Update github release for id ${{ inputs.release_id }}"
-        cd ${{ inputs.module_path }}
-        curl -X PATCH \
-        -H "Accept:application/vnd.github.v3+json" \
-        -d "{\"tag_name\":\"${{ inputs.release_version }}\", \"prerelease\": false, \"draft\": false}" -u \
-        jahia-ci:${{ inputs.github_api_token }} https://api.github.com/repos/${{ inputs.github_slug }}/releases/${{ inputs.release_id }}
-        curl \
-        -H "Content-Type: $(file -b --mime-type CHANGELOG.md)" \
-        -u jahia-ci:${{ inputs.github_api_token }}  \
-        --data-binary @CHANGELOG.md \
-        "https://uploads.github.com/repos/${{ inputs.github_slug }}/releases/${{ inputs.release_id }}/assets?name=$(basename CHANGELOG.md)"
-
     - name: Perform release
       shell: bash
       run: mvn -s ${{ inputs.mvn_settings_filepath }} deploy:deploy-file -Dfile=${{ inputs.module_path }}target/${{ env.MODULE_NAME }}-v${{ env.MODULE_VERSION }}.tgz -DgroupId=${{ env.GROUP_ID }} -DartifactId=${{ env.MODULE_NAME }} -Dversion=${{ env.MODULE_VERSION }} -Dpackaging=tgz -Durl=${{ env.REPOSITORY_URL }} -DrepositoryId=${{ env.REPOSITORY_ID }}

--- a/release/action.yml
+++ b/release/action.yml
@@ -236,21 +236,6 @@ runs:
           release.properties
         key: v1-rollback-${{ inputs.release_id }}
 
-    - name: Update github release for id ${{ inputs.release_id }}
-      shell: bash
-      run: |
-        echo "Update github release for id ${{ inputs.release_id }}"
-        curl --version
-        curl -X PATCH \
-        -H "Accept:application/vnd.github.v3+json" \
-        -d "{\"tag_name\":\"${{ inputs.release_version }}\", \"prerelease\": false, \"draft\": false}" -u \
-        jahia-ci:${{ inputs.github_api_token }} https://api.github.com/repos/${{ inputs.github_slug }}/releases/${{ inputs.release_id }}
-        curl \
-        -H "Content-Type: $(file -b --mime-type CHANGELOG.md)" \
-        -u jahia-ci:${{ inputs.github_api_token }}  \
-        --data-binary @CHANGELOG.md \
-        "https://uploads.github.com/repos/${{ inputs.github_slug }}/releases/${{ inputs.release_id }}/assets?name=$(basename CHANGELOG.md)"
-
     - name: Perform release
       shell: bash
       run: | 


### PR DESCRIPTION
When the GitHub Actions were first created, a process was put in place to upload, if present CHANGELOG.md file to the GitHub Release artifacts.

In ~January 2025, GitHub uploaded the version of curl in their default runner from `7.81.0` to `8.5.0` when they switched from Ubuntu [22.04](https://github.com/actions/runner-images/blob/ubuntu24/20250427.1/images/ubuntu/Ubuntu2204-Readme.md) to [24.04](https://github.com/actions/runner-images/blob/ubuntu24/20250427.1/images/ubuntu/Ubuntu2404-Readme.md). That new version of curl is going to return an exit code 26 if it cannot find the CHANGELOG.md file making the CI step/job to fail (while precedently if was failing silently with a warning).

This is then causing executions of this workflow on Ubuntu 24.04 to fail.

This has never been an issue on module releases, since all of them are running within the cache container `jahia/cimg-mvn-cache:VERSION`, which ships with `curl 7.68.0`, but for jCustomer, which is using the release action directly, [this was failing the release process](https://github.com/Jahia/jcustomer/actions/runs/15071322980/job/42368128952).

### curl 8.5.0 (for example with jCustomer)
```
curl: Failed to open CHANGELOG.md
curl: option --data-binary: error encountered when reading a file
curl: try 'curl --help' or 'curl --manual' for more information
Error: Process completed with exit code 26
```

### curl 7.68.0
```
Warning: Couldn't read data from file "CHANGELOG.md", this makes an empty 
Warning: POST.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   252  100   252    0     0    504      0 --:--:-- --:--:-- --:--:--   502
100   252  100   252    0     0    504      0 --:--:-- --:--:-- --:--:--   502
{"message":"Validation Failed","request_id":"2858:22C48A:53340:5F8AC:682770EE","documentation_url":"https://docs.github.com/rest","errors":[{"resource":"ReleaseAsset","code":"custom","field":"size","message":"size must be greater than or equal to 1"}]}
```

There were two options moving forward, either add a check for the presence of the CHANGELOG.md file before trying to upload it, or remove that part of the action entirely.

Since I don't believe we're using it currently, I opted for removal. We can always add it back (or differently) later on.