### PR TITLE
feat: introducing a github action to connect via wireguard

### DIFF
--- a/vpn-tunnel/action.yml
+++ b/vpn-tunnel/action.yml
@@ -41,7 +41,7 @@ runs:
 
         echo "Checking URL: ${{ inputs.canary-url }}"
         echo "Expected status code: ${{ inputs.canary-http-response }}"
-        echo "Max retry attempts: ${{ inputs.canary-retries }}}"
+        echo "Max retry attempts: ${{ inputs.canary-retries }}"
         echo "Retry interval: $retry_interval seconds"
         
         # Initialize retry counter

--- a/vpn-tunnel/action.yml
+++ b/vpn-tunnel/action.yml
@@ -58,7 +58,6 @@ runs:
           # Make the HTTP request and get the status code
           echo "Attempt $((attempts+1)): Calling URL: ${{ inputs.canary-url }}"
 
-          response_code=$(curl -s -o /dev/null -w "%{http_code}" "${{ inputs.canary-url }}")
           response_code=$(curl -s -w "%{http_code}" "${{ inputs.url }}" -o "$content_file" 2>"$error_file") || true
           curl_exit_code=$?
 

--- a/vpn-tunnel/action.yml
+++ b/vpn-tunnel/action.yml
@@ -43,7 +43,13 @@ runs:
         echo "Expected status code: ${{ inputs.canary-http-response }}"
         echo "Max retry attempts: ${{ inputs.canary-retries }}"
         echo "Retry interval: $retry_interval seconds"
-        
+
+        # Check if URL is empty
+        if [ -z "${{ inputs.url }}" ]; then
+          echo "URL is empty, skipping check"
+          exit 0
+        fi
+
         # Initialize retry counter
         attempts=0
         max_attempts=${{ inputs.canary-retries }}
@@ -53,7 +59,14 @@ runs:
           echo "Attempt $((attempts+1)): Calling URL: ${{ inputs.canary-url }}"
 
           response_code=$(curl -s -o /dev/null -w "%{http_code}" "${{ inputs.canary-url }}")
-          
+          response_code=$(curl -s -w "%{http_code}" "${{ inputs.url }}" -o "$content_file" 2>"$error_file") || true
+          curl_exit_code=$?
+
+          if [ $curl_exit_code -ne 0 ]; then
+            echo "⚠️ curl failed with exit code $curl_exit_code"
+            response_code="curl_error"
+          fi
+
           echo "Attempt $((attempts+1)): Received status code: $response_code"
           
           # Compare the response code with the expected code
@@ -64,12 +77,25 @@ runs:
             attempts=$((attempts+1))
             
             if [ $attempts -lt $max_attempts ]; then
-              echo "⚠️ Expected status code ${{ inputs.canary-http-response }} but got $response_code. Retrying in ${retry_interval}s... (Attempt $attempts/$max_attempts)"
+              if [ "$response_code" = "curl_error" ]; then
+                echo "⚠️ curl error occurred. Error message:"
+                cat "$error_file"
+              else
+                echo "⚠️ Expected status code ${{ inputs.canary-http-response }} but got $response_code."
+              fi            
+              echo "Retrying in ${retry_interval}s... (Attempt $attempts/$max_attempts)"
               sleep $retry_interval
             else
-              echo "❌ Error: Expected status code ${{ inputs.canary-http-response }} but got $response_code after $max_attempts attempts"
-              echo "Retrieving and displaying page content once more..."
-              curl -v -k ${{ inputs.canary-url }}
+              echo "❌ Error: Failed to get expected status code ${{ inputs.canary-http-response }} after $max_attempts attempts"
+              if [ "$response_code" = "curl_error" ]; then
+                echo "---- curl Error Message ----"
+                cat "$error_file"
+                echo "--------------------------"
+              else
+                echo "---- HTTP Response Content ----"
+                cat "$content_file"
+                echo "------------------------------"
+              fi
               exit 1
             fi
           fi

--- a/vpn-tunnel/action.yml
+++ b/vpn-tunnel/action.yml
@@ -1,0 +1,74 @@
+name: Wireguard VPN Tunnel
+description: Establish a Wireguard tunnel using the provided configuration
+
+inputs:
+  config-base64:
+    description: A base64 encoded string of the configuration. Can be generated using "base64 -i wg0.conf -o -"
+    required: true
+  canary-url: 
+    description: A URL to validate the connection with. Will fail if the return code is 
+    required: false  
+    default: ''
+  canary-http-response: 
+    description: The expected HTTP response code when calling the canary-url
+    required: false  
+    default: 200
+  canary-retries: 
+    description: Number of retry attempts if check fails
+    required: false  
+    default: 5    
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Wireguard
+      shell: bash
+      run: |
+        sudo apt install resolvconf
+        sudo apt install wireguard
+
+    - name: Create configuration file
+      shell: bash
+      run: |
+          echo "${{ inputs.config-base64 }}" |base64 -d > wg0.conf
+          sudo chmod 600 wg0.conf
+          sudo wg-quick up ./wg0.conf
+
+    - name: Validate connection using the provided canary URL
+      shell: bash
+      run: |
+        retry_interval=2
+
+        echo "Checking URL: ${{ inputs.canary-url }}"
+        echo "Expected status code: ${{ inputs.canary-http-response }}"
+        echo "Max retry attempts: ${{ inputs.canary-retries }}}"
+        echo "Retry interval: $retry_interval seconds"
+        
+        # Initialize retry counter
+        attempts=0
+        max_attempts=${{ inputs.canary-retries }}
+        
+        while [ $attempts -lt $max_attempts ]; do
+          # Make the HTTP request and get the status code
+          response_code=$(curl -s -o /dev/null -w "%{http_code}" "${{ inputs.canary-url }}")
+          
+          echo "Attempt $((attempts+1)): Received status code: $response_code"
+          
+          # Compare the response code with the expected code
+          if [ "$response_code" = "${{ inputs.canary-http-response }}" ]; then
+            echo "✅ Success: Status code matches expected value ($response_code)"
+            exit 0
+          else
+            attempts=$((attempts+1))
+            
+            if [ $attempts -lt $max_attempts ]; then
+              echo "⚠️ Expected status code ${{ inputs.canary-http-response }} but got $response_code. Retrying in ${retry_interval}s... (Attempt $attempts/$max_attempts)"
+              sleep $retry_interval
+            else
+              echo "❌ Error: Expected status code ${{ inputs.canary-http-response }} but got $response_code after $max_attempts attempts"
+              echo "Retrieving and displaying page content once more..."
+              curl -v -k ${{ inputs.canary-url }}
+              exit 1
+            fi
+          fi
+        done

--- a/vpn-tunnel/action.yml
+++ b/vpn-tunnel/action.yml
@@ -45,7 +45,7 @@ runs:
         echo "Retry interval: $retry_interval seconds"
 
         # Check if URL is empty
-        if [ -z "${{ inputs.url }}" ]; then
+        if [ -z "${{ inputs.canary-url }}" ]; then
           echo "URL is empty, skipping check"
           exit 0
         fi

--- a/vpn-tunnel/action.yml
+++ b/vpn-tunnel/action.yml
@@ -75,6 +75,7 @@ runs:
           else
             attempts=$((attempts+1))
             
+            ls -lah 
             if [ $attempts -lt $max_attempts ]; then
               if [ "$response_code" = "curl_error" ]; then
                 echo "⚠️ curl error occurred. Error message:"

--- a/vpn-tunnel/action.yml
+++ b/vpn-tunnel/action.yml
@@ -50,6 +50,8 @@ runs:
         
         while [ $attempts -lt $max_attempts ]; do
           # Make the HTTP request and get the status code
+          echo "Attempt $((attempts+1)): Calling URL: ${{ inputs.canary-url }}"
+
           response_code=$(curl -s -o /dev/null -w "%{http_code}" "${{ inputs.canary-url }}")
           
           echo "Attempt $((attempts+1)): Received status code: $response_code"


### PR DESCRIPTION
Jahia Cloud resources are only available behind a Wireguard VPN.

This creates a reusable action to establish such a tunnel. The original need is for the jahia-cloud-modules repository, but this would be useful for most tests towards Jahia Cloud internal resources, thus placing it alongside our other actions.

The action will establish the VPN connection and can also validate access to a protected resource using a canary.

### Usage

After merge, before merge you'd need to replace v2 with the branch name.

```yaml
name: SSH Tunnel

on:
  workflow_dispatch:

jobs:
  vpn-tunnel-action:
    runs-on: ubuntu-latest 
    steps:
      - uses: jahia/jahia-modules-action/vpn-tunnel@v2
        with:
          config-base64: ${{ secrets.JC_WIREGUARD_VPN }}
          canary-url: https://app.dev.j.rjahia.com
```