### PR TITLE
fix: fixed incorrect syntax in the workflow

### DIFF
--- a/.github/workflows/reusable-delivery-issue-chores.yml
+++ b/.github/workflows/reusable-delivery-issue-chores.yml
@@ -12,8 +12,15 @@ jobs:
     name: Projects on Labels
     if: ${{ (github.event.action == 'labeled' || github.event.action == 'typed') && github.event.sender.login != 'jahia-ci' }}
     runs-on: ubuntu-latest
-    steps:
-      - name: Displays details about the event
+    steps:   
+      # Issue type is not available by default, this makes it available for if conditions
+      - name: Get Issue type
+        uses: jahia/jahia-modules-action/delivery/get-issue@v2
+        id: get-issue
+        with:
+          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}      
+
+      - name: Displays details about the event and issue
         uses: actions/github-script@v7
         with:
           script: |
@@ -23,14 +30,9 @@ jobs:
             core.info(`context.payload.issue.number: ${context.payload.issue.number}`)
             core.info(`context.payload.issue.html_url: ${context.payload.issue.html_url}`)
             core.info(`context.payload.sender.login: ${context.payload.sender.login}`)
+            core.info(`steps.get-issue.outputs.issue_type: ${{ steps.get-issue.outputs.issue_type }}`)
+            core.info(`steps.get-issue.outputs.issue_number: ${{ steps.get-issue.outputs.issue_number }}`)
             core.debug(context)  
-    
-      # Issue type is not available by default, this makes it available for if conditions
-      - name: Get Issue type
-        uses: jahia/jahia-modules-action/delivery/get-issue@v2
-        id: get-issue
-        with:
-          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}      
 
       # Using an official action from GitHub to attach issues to projects
       # https://github.com/marketplace/actions/add-to-github-projects
@@ -50,14 +52,14 @@ jobs:
 
       - name: Attach all Sup tickets to the product team project
         uses: actions/add-to-project@v1.0.2
-        if: ${{ steps.get-issue.outputs.issue_type == 'Sup' }}}
+        if: ${{ steps.get-issue.outputs.issue_type == 'Sup' }}
         with:
           project-url: https://github.com/orgs/Jahia/projects/50
           github-token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
 
       - name: Attach all Idea tickets to the PM board
         uses: actions/add-to-project@v1.0.2
-        if: ${{ steps.get-issue.outputs.issue_type == 'Idea' }}}
+        if: ${{ steps.get-issue.outputs.issue_type == 'Idea' }}
         with:
           project-url: https://github.com/orgs/Jahia/projects/59
           github-token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
@@ -72,7 +74,7 @@ jobs:
       # Add all tickets of Type "Epic" and label "Area:" to the global roadmap project
       - name: Attach all Epics to the Roadmap - Global project
         uses: actions/add-to-project@v1.0.2
-        if: ${{ steps.get-issue.outputs.issue_type == 'Epic' }}}
+        if: ${{ steps.get-issue.outputs.issue_type == 'Epic' }}
         with:
           project-url: https://github.com/orgs/Jahia/projects/18
           github-token: ${{ secrets.GH_ISSUES_PRS_CHORES }}

--- a/.github/workflows/reusable-delivery-issue-chores.yml
+++ b/.github/workflows/reusable-delivery-issue-chores.yml
@@ -18,7 +18,7 @@ jobs:
         uses: jahia/jahia-modules-action/delivery/get-issue@v2
         id: get-issue
         with:
-          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}      
+          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
 
       - name: Displays details about the event and issue
         uses: actions/github-script@v7


### PR DESCRIPTION
I noticed the workflow was not handling properly issue types, this was likely caused by and extra `}` in the workflow.

I also moved the part displaying debug data to after the collection of the issue number / issue type, to be able to display the outcome of this collection.