### PR TITLE
fix: Enable release workflow commits to release branch

### DIFF
--- a/release-javascript/action.yml
+++ b/release-javascript/action.yml
@@ -140,7 +140,6 @@ runs:
           echo "Commit and push changes to package.json"
           git config user.name ${{ inputs.github_user_name }}
           git config user.email ${{ inputs.github_user_email }}
-          git remote set-url origin https://x-access-token:${{ inputs.github_api_token }}@github.com/${{ inputs.github_slug}}
           git add package.json
           git commit -m "[skip ci] prepare release $FINAL_RELEASE_VERSION"
           git push


### PR DESCRIPTION
the release workflow had this steps
```
```
That was switching the origin from SSH to HTTPS

That step might have been required at a time (it wasn't possible to get to the history when it has been added) but is not required anymore.

Removing this step fixes the release workflow

### Side note
If we need at a time to use the `https` connection, please refer to the [github documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#https) to do the setup