### PR TITLE
fix: update signature after release:prepare

### DIFF
--- a/.github/workflows/reusable-release-module.yml
+++ b/.github/workflows/reusable-release-module.yml
@@ -9,7 +9,7 @@ on:
         type: string
         required: false
         description: "Type of instances to run the job on (self hosted or ubuntu-latest)"
-        default: "ubuntu-latest"    
+        default: "ubuntu-latest"
       mvn_settings_filepath:
         type: string
         description: Filepath to the settings.xml file
@@ -30,11 +30,11 @@ on:
       nexus_username:
         type: string
         required: false
-        default: ""        
+        default: ""
       nexus_password:
         type: string
         required: false
-        default: "" 
+        default: ""
       tests_module_path:
         type: string
         description: "Path to a folder in the repository containing a tests module to be built (Both Javascript and MVN test module supported)"
@@ -44,7 +44,7 @@ on:
         type: string
         description: "Type of module for the tests module (mvn,javascript)"
         required: false
-        default: "mvn"          
+        default: "mvn"
       git_user_name:
         type: string
         description: Git user name
@@ -89,7 +89,7 @@ jobs:
           ssh-private-key: ${{ secrets.GH_SSH_PRIVATE_KEY_JAHIACI }}
 
       # Note: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#limitations
-      # Reusable workflows are called directly within a job, and not from within a job step. 
+      # Reusable workflows are called directly within a job, and not from within a job step.
       # You cannot, therefore, use GITHUB_ENV to pass values to job steps in the caller workflow.
       # Thus using an id and step outputs
       - name: Configure github_slug
@@ -116,7 +116,7 @@ jobs:
             echo "NEXUS_PASSWORD=${{ secrets.NEXUS_PASSWORD }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Displaing defined variables
+      - name: Displaying defined variables
         shell: bash
         run: |
           echo "NEXUS_USERNAME=${{ steps.nexus-creds.outputs.NEXUS_USERNAME }}" 
@@ -155,7 +155,7 @@ jobs:
     needs: release-module
     runs-on: ubuntu-latest
     container:
-      image: cyclonedx/cyclonedx-cli:0.24.2   
+      image: cyclonedx/cyclonedx-cli:0.24.2
     steps:
       - uses: jahia/jahia-modules-action/sbom-processing@v2
         with:

--- a/release/action.yml
+++ b/release/action.yml
@@ -23,7 +23,7 @@ inputs:
   tests_module_type:
     description: 'Type of module for the tests module (mvn,javascript)'
     required: false
-    default: 'mvn'    
+    default: 'mvn'
   github_slug:
     description: 'GitHub SLUG of the module (for example: jahia/sandbox)'
     required: true
@@ -201,7 +201,7 @@ runs:
         echo "final_release_version=${FINAL_RELEASE_VERSION}" >> $GITHUB_OUTPUT
         echo "tag_version=${TAG_VERSION}" >> $GITHUB_OUTPUT
 
-    - name: Release prepare version for ${{ inputs.release_version }}
+    - name: Set version in pom file(s) for ${{ inputs.release_version }}
       shell: bash
       run: |
         echo "FINAL_RELEASE_VERSION=${{ steps.versions.outputs.final_release_version }}"
@@ -223,6 +223,27 @@ runs:
         else
           echo "No test module found"
         fi
+        cd ${GITHUB_WORKSPACE}
+        # Append -SNAPSHOT to the version so the Maven Release Plugin can be used
+        echo "Setting version to ${{ steps.versions.outputs.final_release_version }}-SNAPSHOT"
+        mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} versions:set -DnewVersion="${{ steps.versions.outputs.final_release_version }}-SNAPSHOT"
+        # Only add POM files
+        git add **/pom.xml
+      env:
+        GPG_KEY_PASSPHRASE: ${{ inputs.gpg_key_passphrase }}
+
+    # The POM file(s) may have an invalid signature if the release version differs from the version specified in the POM
+    # (for example, releasing version 1.2.3 when the POM has a signature for a 1.3.0-SNAPSHOT version).
+    - name: Update signature
+      uses: jahia/jahia-modules-action/update-signature@v2
+      with:
+        nexus_username: ${{ inputs.nexus_username }}
+        nexus_password: ${{ inputs.nexus_password }}
+        force_signature: true
+
+    - name: Release prepare version for ${{ inputs.release_version }}
+      shell: bash
+      run: |
         cd ${GITHUB_WORKSPACE}
         mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=${{ steps.versions.outputs.tag_version }} release:prepare -DreleaseVersion="${{ steps.versions.outputs.final_release_version }}" -DdevelopmentVersion="${{ steps.versions.outputs.next_development_version }}" -DscmCommentPrefix="[skip ci] [maven-release-plugin]"
       env:


### PR DESCRIPTION
### Description
Update the Jahia module signature that may become invalid if the release version differs from the version specified in the POM. For example, releasing version 1.2.3 when the POM contains 1.3.0-SNAPSHOT.

### Details

The change is to update the signature right after setting the POM files to the version being released.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
