### PR TITLE
fix: missing root pom.xml when updating signature during release

### DIFF
--- a/.github/workflows/reusable-release-module.yml
+++ b/.github/workflows/reusable-release-module.yml
@@ -122,7 +122,7 @@ jobs:
           echo "NEXUS_USERNAME=${{ steps.nexus-creds.outputs.NEXUS_USERNAME }}" 
           echo "GITHUB_SLUG=${{ steps.slug.outputs.GITHUB_SLUG }}"
 
-      - uses: jahia/jahia-modules-action/release@fix-root-pom-not-added-when-signing
+      - uses: jahia/jahia-modules-action/release@v2
         name: Release Module
         with:
           primary_release_branch: ${{ inputs.primary_release_branch }}

--- a/.github/workflows/reusable-release-module.yml
+++ b/.github/workflows/reusable-release-module.yml
@@ -122,7 +122,7 @@ jobs:
           echo "NEXUS_USERNAME=${{ steps.nexus-creds.outputs.NEXUS_USERNAME }}" 
           echo "GITHUB_SLUG=${{ steps.slug.outputs.GITHUB_SLUG }}"
 
-      - uses: jahia/jahia-modules-action/release@v2
+      - uses: jahia/jahia-modules-action/release@fix-root-pom-not-added-when-signing
         name: Release Module
         with:
           primary_release_branch: ${{ inputs.primary_release_branch }}

--- a/release/action.yml
+++ b/release/action.yml
@@ -228,7 +228,7 @@ runs:
         echo "Setting version to ${{ steps.versions.outputs.final_release_version }}-SNAPSHOT"
         mvn -B -s ${GITHUB_WORKSPACE}/${{ inputs.mvn_settings_filepath }} versions:set -DnewVersion="${{ steps.versions.outputs.final_release_version }}-SNAPSHOT"
         # Only add POM files
-        git add **/pom.xml
+        find . -name pom.xml -exec git add {} \;
       env:
         GPG_KEY_PASSPHRASE: ${{ inputs.gpg_key_passphrase }}
 


### PR DESCRIPTION
### Description
Fix following the change in https://github.com/Jahia/jahia-modules-action/pull/278.
`git add **/pom.xml` does not behave the same in bash (used by the CI) and zsh (used locally when testing).
Because of that, the root `pom.xml` file was not correctly added in the commit updating the signature ([this commit](https://github.com/Jahia/luxe-jahia-demo/commit/1e0c2a2562865354292e14ca33d2425e80422353) for instance).

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
