### PR TITLE
chore: bump dependency-check-maven from 12.1.3 to 12.1.6

### DIFF
--- a/sonar-analysis/action.yml
+++ b/sonar-analysis/action.yml
@@ -37,7 +37,7 @@ inputs:
   java_distribution:
     description: 'Name of the Java distribution to load and use'
     required: false
-    default: 'temurin'    
+    default: 'temurin'
   java_version:
     description: 'Version of Java to load and use for the analysis'
     required: false
@@ -132,7 +132,7 @@ runs:
           echo "Skipping OWASP for PR analysis"
         else
           echo "Executing an OWASP analysis on branch: ${{ inputs.primary_release_branch }}"
-          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.owasp:dependency-check-maven:12.1.3:aggregate \
+          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.owasp:dependency-check-maven:12.1.6:aggregate \
             $SONAR_PARAMS
         fi
 


### PR DESCRIPTION
### Description
Since September 22nd, the OSS Index (Sonatype) requires to authenticate to access their APIs: https://ossindex.sonatype.org/doc/auth-required
This is used internally by the [DependencyCheck plugin](https://github.com/dependency-check/DependencyCheck) that we use in our Sonar Analysis.
Because of that change, the analysis fails (see [this run](https://github.com/Jahia/html-filtering/actions/runs/18151032920/job/51661966242) as an example):
```
Warning:  An error occurred while analyzing '/root/.m2/repository/com/googlecode/owasp-java-html-sanitizer/owasp-java-html-sanitizer/20240325.1/owasp-java-html-sanitizer-20240325.1.jar' (Sonatype OSS Index Analyzer): Failed to request component-reports
Warning:  An error occurred while analyzing '/root/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-properties/2.14.2/jackson-dataformat-properties-2.14.2.jar' (Sonatype OSS Index Analyzer): Failed to request component-reports
Warning:  An error occurred while analyzing '/root/.m2/repository/com/googlecode/owasp-java-html-sanitizer/java8-shim/20240325.1/java8-shim-20240325.1.jar' (Sonatype OSS Index Analyzer): Failed to request component-reports
Warning:  An error occurred while analyzing '/root/.m2/repository/com/googlecode/owasp-java-html-sanitizer/java10-shim/20240325.1/java10-shim-20240325.1.jar' (Sonatype OSS Index Analyzer): Failed to request component-reports
...
Error:  Failed to execute goal org.owasp:dependency-check-maven:12.1.3:aggregate (default-cli) on project html-filtering: One or more exceptions occurred during dependency-check analysis: One or more exceptions occurred during analysis:
Error:  	AnalysisException: Failed to request component-reports
Error:  		caused by DownloadFailedException: https://ossindex.sonatype.org/api/v3/component-report - Server status: 401 - Server reason: Unauthorized
Error:  		caused by HttpResponseException: status code: 401, reason phrase: Unauthorized
Error:  	AnalysisException: Failed to request component-reports
Error:  		caused by DownloadFailedException: https://ossindex.sonatype.org/api/v3/component-report - Server status: 401 - Server reason: Unauthorized
Error:  		caused by HttpResponseException: status code: 401, reason phrase: Unauthorized
Error:  	AnalysisException: Failed to request component-reports
Error:  		caused by DownloadFailedException: https://ossindex.sonatype.org/api/v3/component-report - Server status: 401 - Server reason: Unauthorized
Error:  		caused by HttpResponseException: status code: 401, reason phrase: Unauthorized
Error:  	AnalysisException: Failed to request component-reports
Error:  		caused by DownloadFailedException: https://ossindex.sonatype.org/api/v3/component-report - Server status: 401 - Server reason: Unauthorized
Error:  		caused by HttpResponseException: status code: 401, reason phrase: Unauthorized
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error: Process completed with exit code 1.
```

The [latest 12.1.6 release](https://github.com/dependency-check/DependencyCheck/blob/main/CHANGELOG.md#version-1216-2025-09-24) of DependencyCheck includes [this change](https://github.com/dependency-check/DependencyCheck/pull/7963), that disables the OSS Index analyzer if no credentials are provided.

The alternative is to create an account (free for now) and pass it from the CI.
But we might soon need a paid account... :
> In the near future, Sonatype OSS Index will offer a paid tier for teams and organizations that need unlimited component lookups and no rate limits.


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
