### PR TITLE
chore: updated dorny/test-reporter from v1 to v2.3.0

### DIFF
--- a/.github/workflows/reusable-integration-tests.yml
+++ b/.github/workflows/reusable-integration-tests.yml
@@ -153,7 +153,7 @@ jobs:
           catalina_context: ${{ inputs.catalina_context }}
 
       - name: Test Report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v2.3.0
         if: success() || failure()
         with:
           name: ${{ inputs.test_report_name }}


### PR DESCRIPTION
Description in the title, this might be the cause of this error: 

```
Run dorny/test-reporter@v1
Check runs will be created with SHA=6da778ea327bf0c32fb007b32d94e3ed4c33d064
Listing all files tracked by git
Found 495 files tracked by GitHub
Using test report parser 'java-junit'
Creating test report Tests Report
Error: HttpError: Resource not accessible by integration
```

I checked that the parameters we use in the action are the same between v1 and v2