### PR TITLE
fix: activate OSS Index (Sonatype) in dependency check with credentials

### DIFF
--- a/sonar-analysis/action.yml
+++ b/sonar-analysis/action.yml
@@ -141,6 +141,10 @@ runs:
           SONAR_PARAMS+=" -DnvdApiKey=${{ inputs.nvd_apikey }}"
         fi  
         
+        if [[ -n "${{ secrets.OSS_USERNAME }}" && -n "${{ secrets.OSS_API_TOKEN }}" ]]; then
+          SONAR_PARAMS+=" -DossIndexUsername=${{ secrets.OSS_USERNAME }} -DossIndexPassword=${{ secrets.OSS_API_TOKEN }}"
+        fi  
+        
         echo "SONAR_PARAMS=${SONAR_PARAMS}" >> $GITHUB_ENV
 
     - name: Sonar OWASP


### PR DESCRIPTION
### Description

Using OSS Index (Sonatype) was automatically deactivated with upgrading dependency-check-maven to 12.1.6 (see https://github.com/Jahia/jahia-modules-action/pull/283 ). We now activate it again by passing credentials.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
