### PR TITLE
ci: migrated the simplest reusable workflows from ubuntu-latest to ubuntu-slim

### DIFF
--- a/.github/workflows/reusable-delivery-issue-chores.yml
+++ b/.github/workflows/reusable-delivery-issue-chores.yml
@@ -11,7 +11,7 @@ jobs:
   projects-label:
     name: Projects on Labels
     if: ${{ (github.event.action == 'labeled' || github.event.action == 'typed') && github.event.sender.login != 'jahia-ci' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:   
       # Issue type is not available by default, this makes it available for if conditions
       - name: Get Issue type
@@ -131,7 +131,7 @@ jobs:
   projects-milestone:
     name: Projects on Milestones
     if: ${{ (github.event.action == 'milestoned' || github.event.action == 'demilestoned') && github.event.sender.login != 'jahia-ci' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       # Adds or removes the "Product Team" project if a milestone is added
       # or removed
@@ -143,7 +143,7 @@ jobs:
 
   transfer:
     name: Transfer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [projects-label, projects-milestone]
     if: always() && github.event.sender.login != 'jahia-ci'
     steps:
@@ -189,7 +189,7 @@ jobs:
 
   links:
     name: Links
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: transfer
     if: always() && github.event.sender.login != 'jahia-ci'
     steps:

--- a/.github/workflows/reusable-delivery-pr-chores.yml
+++ b/.github/workflows/reusable-delivery-pr-chores.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   lint-pr-title:
     name: Lint PR Title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     # It does not make sense to run that workflow when a PR is closed
     if: ${{ github.event.action != 'closed' }}
     steps:
@@ -68,7 +68,7 @@ jobs:
   # When closing the PR, label it based on conventional commits
   # https://github.com/marketplace/actions/conventionnal-commit-pr-labeler
   label-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     name: Apply label base on conventional commit
     if: ${{ github.event.action == 'closed' }}
     steps:


### PR DESCRIPTION
Following the introduction of slim runners and recommendation to use them for simple workflows (such as issues and pr chores)

https://github.blog/changelog/2026-01-22-1-vcpu-linux-runner-now-generally-available-in-github-actions/

