### PR TITLE
ci: exposed the tests_path input to the reusable workflow

### DIFF
--- a/.github/workflows/reusable-integration-tests.yml
+++ b/.github/workflows/reusable-integration-tests.yml
@@ -169,6 +169,6 @@ jobs:
         if: success() || failure()
         with:
           name: ${{ inputs.test_report_name }}
-          path: tests/artifacts/results/xml_reports/**/*.xml
+          path: ${{ inputs.tests_path }}/artifacts/results/xml_reports/**/*.xml
           reporter: java-junit
           fail-on-error: "false"


### PR DESCRIPTION
This was needed to use the reusable workflow for jahia-ee, since the tests are in a different folder than default