### PR TITLE
fix: switch back to ubuntu-latest for jobs using a docker action

### DIFF
--- a/.github/workflows/reusable-delivery-issue-chores.yml
+++ b/.github/workflows/reusable-delivery-issue-chores.yml
@@ -143,7 +143,7 @@ jobs:
 
   transfer:
     name: Transfer
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     needs: [projects-label, projects-milestone]
     if: always() && github.event.sender.login != 'jahia-ci'
     steps:


### PR DESCRIPTION
Last week we switched to the new ubuntu-slim runners, but these are causing issues with GitHub Actions using docker (which we don't especially see except by inspecting the action itself).

Issue explaining the problem: https://github.com/actions/runner-images/issues/13583