### PR TITLE
feat: Support npm publish token in reusable release wkf

### DIFF
--- a/.github/workflows/reusable-release-module.yml
+++ b/.github/workflows/reusable-release-module.yml
@@ -60,11 +60,6 @@ on:
         description: "Time during which artifact are kept in Github infrastructure"
         required: false
         default: "2"
-      npmjs_publish_token:
-        type: string
-        description: 'Token used to publish javascript module (or any kind of npm package) to npmjs.com, typically used when the Maven release process delegates the package publication to npm'
-        default: ''
-        required: false
 
 jobs:
   release-module:
@@ -148,7 +143,7 @@ jobs:
           gpg_key: ${{ secrets.GPG_KEY }}
           gpg_key_id: ${{ secrets.GPG_KEY_ID }}
           gpg_key_passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
-          npmjs_publish_token: ${{ inputs.npmjs_publish_token }}
+          npmjs_publish_token: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 
       - uses: jahia/jahia-modules-action/update-signature@v2
         with:

--- a/release/action.yml
+++ b/release/action.yml
@@ -82,7 +82,6 @@ runs:
         echo "NEXUS_PASSWORD=${{ inputs.nexus_password }}" >> $GITHUB_ENV
         echo "NEXUS_RELEASE_USERNAME=${{ inputs.nexus_username }}" >> $GITHUB_ENV
         echo "NEXUS_RELEASE_PASSWORD=${{ inputs.nexus_password }}" >> $GITHUB_ENV
-        echo "NEXUS_RELEASE_PASSWORD=${{ inputs.npmjs_publish_token }}" >> $GITHUB_ENV
         # It is important that this environment variable always reflects the output of the tty command for all shell invocations (gpg-agent doc)
         echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
 


### PR DESCRIPTION
Closes https://github.com/Jahia/user-password-authentication/issues/118.
### Description

Support the npm publication token in the reusable release workflow.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
