### PR TITLE
fix(revert): Remove npm publish token in reusable release wkf

### DIFF
--- a/.github/workflows/reusable-release-module.yml
+++ b/.github/workflows/reusable-release-module.yml
@@ -143,7 +143,6 @@ jobs:
           gpg_key: ${{ secrets.GPG_KEY }}
           gpg_key_id: ${{ secrets.GPG_KEY_ID }}
           gpg_key_passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
-          npmjs_publish_token: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 
       - uses: jahia/jahia-modules-action/update-signature@v2
         with:

--- a/release/action.yml
+++ b/release/action.yml
@@ -82,6 +82,7 @@ runs:
         echo "NEXUS_PASSWORD=${{ inputs.nexus_password }}" >> $GITHUB_ENV
         echo "NEXUS_RELEASE_USERNAME=${{ inputs.nexus_username }}" >> $GITHUB_ENV
         echo "NEXUS_RELEASE_PASSWORD=${{ inputs.nexus_password }}" >> $GITHUB_ENV
+        echo "NEXUS_RELEASE_PASSWORD=${{ inputs.npmjs_publish_token }}" >> $GITHUB_ENV
         # It is important that this environment variable always reflects the output of the tty command for all shell invocations (gpg-agent doc)
         echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
 


### PR DESCRIPTION
This reverts commit 1eac79058463feb3f709981f6ef9410398d68f57.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
