### PR TITLE
feat: add documentation instructions if changes to the docs/ folder

### DIFF
--- a/.github/workflows/reusable-delivery-pr-chores.yml
+++ b/.github/workflows/reusable-delivery-pr-chores.yml
@@ -71,7 +71,7 @@ jobs:
     name: Post documentation guidelines
     if: ${{ github.event.action != 'closed' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Check if changes took place in the docs/ folder
       - uses: dorny/paths-filter@v3


### PR DESCRIPTION
### Description

The new documentation mechanism is not necessarily straight-forward for those not familiar with it.

This PR adds a comment to any PR containing changes in the docs/ folder, this comment contains links to documentation. If for any reason, docs folder is removed on an opened PR, the comment is also deleted.