### PR TITLE
fix(chachalog-default-config): don't create a default version file if the config exists

### DIFF
--- a/chachalog-default-config/action.yml
+++ b/chachalog-default-config/action.yml
@@ -37,7 +37,9 @@ runs:
       run: |
         set -euo pipefail
         version_file="${{ inputs.config-file-version }}"
-        if [ ! -f "$version_file" ]; then
+        config_file="${{ inputs.config-file }}"
+        # If the config file exists, we assume the version file (if needed) exists
+        if [ ! -f "$config_file" ]; then
           mkdir -p "$(dirname "$version_file")"
           echo "0.0.0" > "$version_file"
           echo "Created $version_file with 0.0.0"


### PR DESCRIPTION
### Description

The "0.0.0" version file should not be created if the config file already exists (because it might be using `yarn()` or something else)

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
