### PR TITLE
chore: Add user mentions workflow for issue comments

### DIFF
--- a/.github/workflows/reusable-delivery-issue-chores.yml
+++ b/.github/workflows/reusable-delivery-issue-chores.yml
@@ -257,9 +257,7 @@ jobs:
           SLACK_TO_GITHUB_ID_MAP: ${{ secrets.SLACK_TO_GITHUB_ID_MAP }}
           MENTIONS: ${{ steps.mentions.outputs.mentions }}
           REPO: ${{ github.repository }}
-          ISSUE_URL: ${{ github.event.issue.html_url }}
           COMMENT_URL: ${{ github.event.comment.html_url }}
-          EVENT_NAME: ${{ github.event_name }}
           ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
@@ -272,21 +270,12 @@ jobs:
               continue
             fi
 
-            # Link to the relevant place
-            if [ "$EVENT_NAME" = "issue_comment" ] && [ -n "${COMMENT_URL:-}" ] && [ "$COMMENT_URL" != "null" ]; then
-              link="$COMMENT_URL"
-              link_label="View comment"
-            else
-              link="$ISSUE_URL"
-              link_label="View issue"
-            fi
-
             payload="$(jq -n \
               --arg channel "$slack_id" \
               --arg repo "$REPO" \
               --arg actor "$ACTOR" \
-              --arg link "$link" \
-              --arg link_label "$link_label" \
+              --arg link "$COMMENT_URL" \
+              --arg link_label "View comment" \
               '{
                 channel: $channel,
                 text: ($repo + ": you were mentioned by @" + $actor),


### PR DESCRIPTION
### Description

Tested with: https://github.com/Jahia/sandbox/actions/runs/22492238622/job/65157370459

We'll receive this notification:
<img width="836" height="468" alt="image" src="https://github.com/user-attachments/assets/863e8cca-b3f7-4f8e-ab0e-763f46c5610f" />

The only issue is that it is based on a mapping (GitHub/Slack IDs) stored in the secrets

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
