### PR TITLE
fix(chachalog-default-config): don't crash when there is no version file

### DIFF
--- a/chachalog-default-config/action.yml
+++ b/chachalog-default-config/action.yml
@@ -145,4 +145,4 @@ runs:
         echo "=== Displaying Chachalog config at: ${{ inputs.config-file }} ==="
         cat ${{ inputs.config-file }}
         echo "=== Displaying Chachalog version at: ${{ inputs.config-file-version }}==="
-        cat ${{ inputs.config-file-version }}
+        cat ${{ inputs.config-file-version }} || echo "Version file not found"


### PR DESCRIPTION
### Description

Fix this failure: https://github.com/Jahia/moonstone/actions/runs/22567305395/job/65366206686?pr=1286

When a repo has its own chachalog config that has a real package manager (e.g. moonstone with yarn), it does not have a version file

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
