### PR TITLE
chore: exclude PM repository from bug triage

### DIFF
--- a/.github/workflows/reusable-delivery-issue-chores.yml
+++ b/.github/workflows/reusable-delivery-issue-chores.yml
@@ -37,6 +37,7 @@ jobs:
       # Using an official action from GitHub to attach issues to projects
       # https://github.com/marketplace/actions/add-to-github-projects
       - name: Attach needs-triage label to the Bugs Triage project
+        if: ${{ (github.repository != 'Jahia/pm') }}  # exclude pm repository since we don't want to add all issues to the triage project
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/Jahia/projects/13


### PR DESCRIPTION
Exclude pm project from the workflow to add the label "need-triage".
Issues added to the pm project, don't need to be in the triage workflow of the QA team.
