### PR TITLE
fix: make cache/mirror handling more robust and configurable

### DIFF
--- a/.github/workflows/reusable-sonar-scan.yml
+++ b/.github/workflows/reusable-sonar-scan.yml
@@ -69,7 +69,7 @@ jobs:
           mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-      - uses: jahia/jahia-modules-action/sonar-analysis@v2
+      - uses: jahia/jahia-modules-action/sonar-analysis@fix_sonar_depcheck_cache
         with:
           primary_release_branch: ${{ inputs.git_branch }}
           build_artifacts: ""

--- a/.github/workflows/reusable-sonar-scan.yml
+++ b/.github/workflows/reusable-sonar-scan.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           distribution: ${{ inputs.java_distribution }}
           java-version: ${{ inputs.java_version }}
-      - uses: jahia/jahia-modules-action/build@v2
+      - uses: jahia/jahia-modules-action/build@fix_sonar_depcheck_cache
         with:
           tests_module_type: ${{ inputs.tests_module_type }}
           mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}

--- a/.github/workflows/reusable-sonar-scan.yml
+++ b/.github/workflows/reusable-sonar-scan.yml
@@ -77,6 +77,8 @@ jobs:
           sonar_url: ${{ secrets.SONAR_URL }}
           sonar_token: ${{ secrets.SONAR_TOKEN }}
           nvd_apikey: ${{ secrets.NVD_APIKEY }}
+          nvd_datafeed_url: ${{ vars.NVD_DATAFEED_URL }}
+          cisa_known_exploited_vuln_url: ${{ vars.CISA_KNOWN_EXPLOITED_VULN_URL }}
           oss_username: ${{ secrets.OSS_USERNAME }}
           oss_apitoken: ${{ secrets.OSS_API_TOKEN }}
           mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}

--- a/.github/workflows/reusable-sonar-scan.yml
+++ b/.github/workflows/reusable-sonar-scan.yml
@@ -69,7 +69,7 @@ jobs:
           mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-      - uses: jahia/jahia-modules-action/sonar-analysis@fix_sonar_depcheck_cache
+      - uses: jahia/jahia-modules-action/sonar-analysis@v2
         with:
           primary_release_branch: ${{ inputs.git_branch }}
           build_artifacts: ""

--- a/.github/workflows/reusable-sonar-scan.yml
+++ b/.github/workflows/reusable-sonar-scan.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           distribution: ${{ inputs.java_distribution }}
           java-version: ${{ inputs.java_version }}
-      - uses: jahia/jahia-modules-action/build@fix_sonar_depcheck_cache
+      - uses: jahia/jahia-modules-action/build@v2
         with:
           tests_module_type: ${{ inputs.tests_module_type }}
           mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}

--- a/build-step-mvn/action.yml
+++ b/build-step-mvn/action.yml
@@ -44,6 +44,16 @@ runs:
         echo "NEXUS_USERNAME=${{ inputs.nexus_username }}" >> $GITHUB_ENV
         echo "NEXUS_PASSWORD=${{ inputs.nexus_password }}" >> $GITHUB_ENV
 
+    - name: Generate Maven cache key
+      shell: bash
+      run: |
+        find . -name 'pom.xml' -type f | sort | xargs cat > maven_cache_seed || true
+        if [[ -s maven_cache_seed ]]; then
+          echo "MAVEN_CACHE_KEY_SUFFIX=$(sha256sum maven_cache_seed | cut -d' ' -f1)" >> $GITHUB_ENV
+        else
+          echo "MAVEN_CACHE_KEY_SUFFIX=no-pom" >> $GITHUB_ENV
+        fi
+
     # This step save the maven cache between runs
     # More details can be found here: https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows
     - name: Cache local Maven repository
@@ -52,7 +62,7 @@ runs:
         path: |
           ~/.m2/repository
           /root/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-maven-${{ env.MAVEN_CACHE_KEY_SUFFIX }}
         restore-keys: |
           ${{ runner.os }}-maven-
 

--- a/build/action.yml
+++ b/build/action.yml
@@ -43,7 +43,7 @@ runs:
   using: 'composite'
   steps:
     - name: Build package
-      uses: jahia/jahia-modules-action/build-step-mvn@v2
+      uses: jahia/jahia-modules-action/build-step-mvn@fix_sonar_depcheck_cache
       with:
         mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
         nexus_username: ${{ inputs.nexus_username }}
@@ -59,7 +59,7 @@ runs:
         files: "${{ inputs.tests_module_path }}pom.xml"
 
     - name: Build tests package (MVN)
-      uses: jahia/jahia-modules-action/build-step-mvn@v2
+      uses: jahia/jahia-modules-action/build-step-mvn@fix_sonar_depcheck_cache
       if: ${{ inputs.tests_module_type == 'mvn' && steps.check_test_module_mvn.outputs.files_exists == 'true' }}
       with:
         module_path: ${{ inputs.tests_module_path }}

--- a/build/action.yml
+++ b/build/action.yml
@@ -43,7 +43,7 @@ runs:
   using: 'composite'
   steps:
     - name: Build package
-      uses: jahia/jahia-modules-action/build-step-mvn@fix_sonar_depcheck_cache
+      uses: jahia/jahia-modules-action/build-step-mvn@v2
       with:
         mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
         nexus_username: ${{ inputs.nexus_username }}
@@ -59,7 +59,7 @@ runs:
         files: "${{ inputs.tests_module_path }}pom.xml"
 
     - name: Build tests package (MVN)
-      uses: jahia/jahia-modules-action/build-step-mvn@fix_sonar_depcheck_cache
+      uses: jahia/jahia-modules-action/build-step-mvn@v2
       if: ${{ inputs.tests_module_type == 'mvn' && steps.check_test_module_mvn.outputs.files_exists == 'true' }}
       with:
         module_path: ${{ inputs.tests_module_path }}

--- a/dependencies-check-java/action.yml
+++ b/dependencies-check-java/action.yml
@@ -45,11 +45,32 @@ runs:
           echo "Base POM not found"
         fi
 
+    - name: Generate base cache key seed
+      shell: bash
+      if: ${{ env.BASE_POM_NOT_FOUND == 0 }}
+      run: |
+        find "${BASE_REPO_DIR}" -name 'pom.xml' -type f | sort | xargs cat > base_maven_cache_seed || true
+        if [[ -s base_maven_cache_seed ]]; then
+          echo "BASE_MAVEN_CACHE_KEY_SUFFIX=$(sha256sum base_maven_cache_seed | cut -d' ' -f1)" >> $GITHUB_ENV
+        else
+          echo "BASE_MAVEN_CACHE_KEY_SUFFIX=no-pom" >> $GITHUB_ENV
+        fi
+
+    - name: Generate local cache key seed
+      shell: bash
+      run: |
+        find . -name 'pom.xml' -type f | sort | xargs cat > local_maven_cache_seed || true
+        if [[ -s local_maven_cache_seed ]]; then
+          echo "LOCAL_MAVEN_CACHE_KEY_SUFFIX=$(sha256sum local_maven_cache_seed | cut -d' ' -f1)" >> $GITHUB_ENV
+        else
+          echo "LOCAL_MAVEN_CACHE_KEY_SUFFIX=no-pom" >> $GITHUB_ENV
+        fi
+
     - name: Restore base dependencies from cache
       uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       if: ${{ env.BASE_POM_NOT_FOUND == 0 }}
       with:
-        key: ${{ runner.os }}-maven-${{ hashFiles('/tmp/base-repo/**/pom.xml') }}
+        key: ${{ runner.os }}-maven-${{ env.BASE_MAVEN_CACHE_KEY_SUFFIX }}
         path: ~/.m2/repository
 
     - name: Get dependencies from base POM
@@ -63,7 +84,7 @@ runs:
       uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       if: ${{ env.BASE_POM_NOT_FOUND == 0 }}
       with:
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-maven-${{ env.LOCAL_MAVEN_CACHE_KEY_SUFFIX }}
         path: ~/.m2/repository
 
     - name: Get dependencies from local POM

--- a/dependencies-get-new-versions-java/action.yml
+++ b/dependencies-get-new-versions-java/action.yml
@@ -17,10 +17,20 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Generate Maven cache key
+      shell: bash
+      run: |
+        find . -name 'pom.xml' -type f | sort | xargs cat > maven_cache_seed || true
+        if [[ -s maven_cache_seed ]]; then
+          echo "MAVEN_CACHE_KEY_SUFFIX=$(sha256sum maven_cache_seed | cut -d' ' -f1)" >> $GITHUB_ENV
+        else
+          echo "MAVEN_CACHE_KEY_SUFFIX=no-pom" >> $GITHUB_ENV
+        fi
+
     - name: Save/Restore dependencies from cache
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-maven-${{ env.MAVEN_CACHE_KEY_SUFFIX }}
         path: |
           ~/.m2
 

--- a/dependencies-get-unused-java/action.yml
+++ b/dependencies-get-unused-java/action.yml
@@ -15,10 +15,20 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Generate Maven cache key
+      shell: bash
+      run: |
+        find . -name 'pom.xml' -type f | sort | xargs cat > maven_cache_seed || true
+        if [[ -s maven_cache_seed ]]; then
+          echo "MAVEN_CACHE_KEY_SUFFIX=$(sha256sum maven_cache_seed | cut -d' ' -f1)" >> $GITHUB_ENV
+        else
+          echo "MAVEN_CACHE_KEY_SUFFIX=no-pom" >> $GITHUB_ENV
+        fi
+
     - name: Save/Restore dependencies from cache
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-maven-${{ env.MAVEN_CACHE_KEY_SUFFIX }}
         path: |
           ~/.m2
 

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -34,6 +34,16 @@ runs:
         echo "NEXUS_USERNAME=${{ inputs.nexus_username }}" >> $GITHUB_ENV
         echo "NEXUS_PASSWORD=${{ inputs.nexus_password }}" >> $GITHUB_ENV
 
+    - name: Generate Maven cache key
+      shell: bash
+      run: |
+        find . -name 'pom.xml' -type f | sort | xargs cat > maven_cache_seed || true
+        if [[ -s maven_cache_seed ]]; then
+          echo "MAVEN_CACHE_KEY_SUFFIX=$(sha256sum maven_cache_seed | cut -d' ' -f1)" >> $GITHUB_ENV
+        else
+          echo "MAVEN_CACHE_KEY_SUFFIX=no-pom" >> $GITHUB_ENV
+        fi
+
     # This step save the maven cache between runs
     # More details can be found here: https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows
     - name: Cache local Maven repository
@@ -42,7 +52,7 @@ runs:
         path: |
           ~/.m2/repository
           /root/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-maven-${{ env.MAVEN_CACHE_KEY_SUFFIX }}
         restore-keys: |
           ${{ runner.os }}-maven-
 

--- a/release/action.yml
+++ b/release/action.yml
@@ -73,7 +73,7 @@ inputs:
     required: false
   skip_staging:
     description: 'Skip staging repository (e.g. for Jahia Cloud releases)'
-    default: false
+    default: 'false'
     required: false
 
 runs:
@@ -113,6 +113,11 @@ runs:
       shell: bash
       run: |
         find . -name 'pom.xml' | sort | xargs cat > ./maven_cache_seed
+        if [[ -s ./maven_cache_seed ]]; then
+          echo "MAVEN_CACHE_KEY_SUFFIX=$(sha256sum ./maven_cache_seed | cut -d' ' -f1)" >> $GITHUB_ENV
+        else
+          echo "MAVEN_CACHE_KEY_SUFFIX=no-pom" >> $GITHUB_ENV
+        fi
 
     - name: Cache local Maven repository
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
@@ -120,9 +125,9 @@ runs:
         path: |
           ~/.m2/repository
           /root/.m2/repository
-        key: v1-maven-dependencies-${{ hashFiles('**/maven_cache_seed') }}
+        key: v1-maven-dependencies-${{ env.MAVEN_CACHE_KEY_SUFFIX }}
         restore-keys: |
-          v1-maven-dependencies-${{ hashFiles('**/maven_cache_seed') }}
+          v1-maven-dependencies-
 
     - name: Prepare GPG
       if: ${{ inputs.sign_commits == 'true' }}

--- a/sonar-analysis/action.yml
+++ b/sonar-analysis/action.yml
@@ -93,6 +93,9 @@ runs:
       run: |
         echo "SONAR_URL=${{ inputs.sonar_url }}" >> $GITHUB_ENV
         echo "SONAR_TOKEN=${{ inputs.sonar_token }}" >> $GITHUB_ENV
+        echo "SONAR_USER_HOME=${GITHUB_WORKSPACE}/.cache/sonar" >> $GITHUB_ENV
+        echo "SONAR_CACHE_DIR=${GITHUB_WORKSPACE}/.cache/sonar/cache" >> $GITHUB_ENV
+        echo "OWASP_DATA_DIR=${GITHUB_WORKSPACE}/.cache/owasp/dependency-check-data" >> $GITHUB_ENV
 
     - name: Displaying important variables
       shell: bash
@@ -102,12 +105,12 @@ runs:
     - name: Prepare Sonar cache directory
       shell: bash
       run: |
-        mkdir -p ~/.sonar/cache
+        mkdir -p "${SONAR_CACHE_DIR}"
 
     - name: Cache local Sonar data
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
-        path: ~/.sonar/cache
+        path: ${{ env.SONAR_CACHE_DIR }}
         key: v1-sonar-cache-${{ runner.os }}
         restore-keys: |
           v1-sonar-cache-
@@ -116,13 +119,13 @@ runs:
       shell: bash
       if: ${{ inputs.github_pr_id == '' }}
       run: |
-        mkdir -p ~/.owasp/dependency-check-data
+        mkdir -p "${OWASP_DATA_DIR}"
 
     - name: Cache local OWASP Dependency-Check data
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       if: ${{ inputs.github_pr_id == '' }}
       with:
-        path: ~/.owasp/dependency-check-data
+        path: ${{ env.OWASP_DATA_DIR }}
         key: v1-owasp-dependencies-${{ hashFiles('maven_cache_seed') }}
         restore-keys: |
           v1-owasp-dependencies-
@@ -148,7 +151,7 @@ runs:
           -Dsonar.dependencyCheck.jsonReportPath=target/dependency-check-report.json \
           -Dsonar.dependencyCheck.htmlReportPath=target/dependency-check-report.html \
           -DretireJsAnalyzerEnabled=false -DnodeAnalyzerEnabled=false -DassemblyAnalyzerEnabled=false -DnodeAuditSkipDevDependencies=true \
-          -DyarnAuditAnalyzerEnabled=false -DdataDirectory=~/.owasp/dependency-check-data"
+          -DyarnAuditAnalyzerEnabled=false -Dsonar.userHome=${SONAR_USER_HOME} -DdataDirectory=${OWASP_DATA_DIR}"
           
         DEFAULT_SUPP="https://raw.githubusercontent.com/Jahia/jahia/master/.owasp/suppressions.xml"
         supps=("$DEFAULT_SUPP")
@@ -215,4 +218,20 @@ runs:
           mvn -B -s ${{ inputs.mvn_settings_filepath }} org.sonarsource.scanner.maven:sonar-maven-plugin:5.6.0.6792:sonar \
             -Dsonar.branch.name=${{ inputs.primary_release_branch }} \
             $SONAR_PARAMS
+        fi
+
+    - name: Display cache directories usage
+      shell: bash
+      if: ${{ always() }}
+      run: |
+        echo "HOME: ${HOME}"
+        echo "GITHUB_WORKSPACE: ${GITHUB_WORKSPACE}"
+        echo "SONAR_USER_HOME: ${SONAR_USER_HOME}"
+        echo "Sonar cache directory status"
+        du -sh "${SONAR_CACHE_DIR}" 2>/dev/null || true
+        find "${SONAR_CACHE_DIR}" -type f 2>/dev/null | wc -l || true
+        if [[ "${{ inputs.github_pr_id }}" == "" ]]; then
+          echo "OWASP cache directory status"
+          du -sh "${OWASP_DATA_DIR}" 2>/dev/null || true
+          find "${OWASP_DATA_DIR}" -type f 2>/dev/null | wc -l || true
         fi

--- a/sonar-analysis/action.yml
+++ b/sonar-analysis/action.yml
@@ -42,8 +42,16 @@ inputs:
     description: 'Version of Java to load and use for the analysis'
     required: false
     default: '11'
+  nvd_datafeed_url:
+    description: 'NVD Datafeed URL to bootstrap/refresh the bulk vulnerability database. Can be combined with nvd_apikey: the feed bootstraps the bulk DB, the API key fetches incremental deltas on top.'
+    required: false
+    default: 'https://dependency-check.github.io/DependencyCheck_Builder/nvd_cache/'
   nvd_apikey:
-    description: 'NVD API Key to download vulnerability database'
+    description: 'NVD API Key for incremental delta updates via the NVD REST API. Can be combined with nvd_datafeed_url: the feed bootstraps the bulk DB, the API key fetches deltas on top.'
+    required: false
+    default: ''
+  cisa_known_exploited_vuln_url:
+    description: 'URL for the CISA Known Exploited Vulnerabilities catalog JSON feed. When empty, defaults to the official CISA feed. Override to use an internal mirror.'
     required: false
     default: ''
   oss_username:
@@ -79,11 +87,6 @@ runs:
       shell: bash
       run: |
         find . -name 'pom.xml' | sort | xargs cat > maven_cache_seed
-        if [[ ! -z "${{ inputs.github_pr_id }}" ]]; then
-          echo "true" > is_pr
-        else
-          echo "false" > is_pr
-        fi
 
     - name: Set environment variables from parameters
       shell: bash
@@ -96,15 +99,33 @@ runs:
       run: |
         echo "github_pr_id = ${{ inputs.github_pr_id }}"
 
-    - name: Cache local Maven repository
+    - name: Prepare Sonar cache directory
+      shell: bash
+      run: |
+        mkdir -p ~/.sonar/cache
+
+    - name: Cache local Sonar data
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
-        path: |
-          ~/.owasp/dependency-check-data
-          ~/.sonar/cache
-        key: v3-sonar-owasp-dependencies-{{ checksum "is_pr" }}
+        path: ~/.sonar/cache
+        key: v1-sonar-cache-${{ runner.os }}
         restore-keys: |
-          v3-sonar-owasp-dependencies-{{ checksum "is_pr" }}
+          v1-sonar-cache-
+
+    - name: Prepare OWASP cache directory
+      shell: bash
+      if: ${{ inputs.github_pr_id == '' }}
+      run: |
+        mkdir -p ~/.owasp/dependency-check-data
+
+    - name: Cache local OWASP Dependency-Check data
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      if: ${{ inputs.github_pr_id == '' }}
+      with:
+        path: ~/.owasp/dependency-check-data
+        key: v1-owasp-dependencies-${{ hashFiles('maven_cache_seed') }}
+        restore-keys: |
+          v1-owasp-dependencies-
 
     - name: Setup Sonar env variables
       shell: bash
@@ -144,14 +165,21 @@ runs:
           
         SONAR_PARAMS+=" -DsuppressionFiles=${SUPPRESSION_LIST}"  
           
-        # Optional NVD API key (only add if provided)
+        # Optional NVD parameters - datafeed and API key are complementary:
+        # datafeed bootstraps/refreshes the bulk DB, API key fetches incremental deltas on top
+        if [[ -n "${{ inputs.nvd_datafeed_url }}" ]]; then
+          SONAR_PARAMS+=" -DnvdDatafeedUrl=${{ inputs.nvd_datafeed_url }}"
+        fi
         if [[ -n "${{ inputs.nvd_apikey }}" ]]; then
           SONAR_PARAMS+=" -DnvdApiKey=${{ inputs.nvd_apikey }}"
-        fi  
+        fi
+        if [[ -n "${{ inputs.cisa_known_exploited_vuln_url }}" ]]; then
+          SONAR_PARAMS+=" -DknownExploitedUrl=${{ inputs.cisa_known_exploited_vuln_url }}"
+        fi
         
         if [[ -n "${{ inputs.oss_username }}" && -n "${{ inputs.oss_apitoken }}" ]]; then
           SONAR_PARAMS+=" -DossIndexUsername=${{ inputs.oss_username }} -DossIndexPassword=${{ inputs.oss_apitoken }} \
-            -DossindexAnalyzerUrl=https://api.guide.sonatype.com -DossindexAnalyzerUseCache=false"
+            -DossindexAnalyzerUrl=https://api.guide.sonatype.com -DossindexAnalyzerUseCache=true"
         else    
           SONAR_PARAMS+=" -DossindexAnalyzerEnabled=false"
         fi  
@@ -160,15 +188,11 @@ runs:
 
     - name: Sonar OWASP
       shell: bash
+      if: ${{ inputs.github_pr_id == '' }}
       run: |
-        echo "Pull request number: ${{ inputs.github_pr_id }}"
-        if [[ ! -z "${{ inputs.github_pr_id }}" ]]; then
-          echo "Skipping OWASP for PR analysis"
-        else
-          echo "Executing an OWASP analysis on branch: ${{ steps.vars.outputs.branch }}"
-          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.owasp:dependency-check-maven:12.1.9:aggregate \
-            $SONAR_PARAMS
-        fi
+        echo "Executing an OWASP analysis on branch: ${{ steps.vars.outputs.branch }}"
+        mvn -B -s ${{ inputs.mvn_settings_filepath }} org.owasp:dependency-check-maven:12.2.1:aggregate \
+          $SONAR_PARAMS
 
     - name: Sonar Release branch analysis
       shell: bash
@@ -177,18 +201,18 @@ runs:
         echo "Pull request number: ${{ inputs.github_pr_id }}"
         if [[ ! -z "${{ inputs.github_pr_id }}" ]]; then
           echo "Executing a PR based analysis"
-          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.sonarsource.scanner.maven:sonar-maven-plugin:5.3.0.6276:sonar \
+          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.sonarsource.scanner.maven:sonar-maven-plugin:5.6.0.6792:sonar \
               -Dsonar.pullrequest.branch=$GITHUB_REF \
               -Dsonar.pullrequest.key=${{ inputs.github_pr_id }} \
               -Dsonar.pullrequest.base=${{ inputs.primary_release_branch }} \
               -Dsonar.pullrequest.github.repository=${{ steps.vars.outputs.github_slug }}
         elif [[ ${{ steps.vars.outputs.branch }} == ${{ inputs.primary_release_branch }} ]]; then
           echo "Executing an analysis on the main branch"
-          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.sonarsource.scanner.maven:sonar-maven-plugin:5.3.0.6276:sonar \
+          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.sonarsource.scanner.maven:sonar-maven-plugin:5.6.0.6792:sonar \
             $SONAR_PARAMS
         else
           echo "Executing an analysis on branch: ${{ inputs.primary_release_branch }}"
-          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.sonarsource.scanner.maven:sonar-maven-plugin:5.3.0.6276:sonar \
+          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.sonarsource.scanner.maven:sonar-maven-plugin:5.6.0.6792:sonar \
             -Dsonar.branch.name=${{ inputs.primary_release_branch }} \
             $SONAR_PARAMS
         fi

--- a/sonar-analysis/action.yml
+++ b/sonar-analysis/action.yml
@@ -83,50 +83,66 @@ runs:
       with:
         name: ${{ inputs.build_artifacts }}
 
-    - name: Generate Cache Key Seeds
-      shell: bash
-      run: |
-        find . -name 'pom.xml' | sort | xargs cat > maven_cache_seed
-
     - name: Set environment variables from parameters
       shell: bash
       run: |
         echo "SONAR_URL=${{ inputs.sonar_url }}" >> $GITHUB_ENV
         echo "SONAR_TOKEN=${{ inputs.sonar_token }}" >> $GITHUB_ENV
+        if [[ -n "${{ inputs.nvd_apikey }}" ]]; then
+          echo "NVD_API_KEY=${{ inputs.nvd_apikey }}" >> $GITHUB_ENV
+        fi
         echo "SONAR_USER_HOME=${GITHUB_WORKSPACE}/.cache/sonar" >> $GITHUB_ENV
         echo "SONAR_CACHE_DIR=${GITHUB_WORKSPACE}/.cache/sonar/cache" >> $GITHUB_ENV
         echo "OWASP_DATA_DIR=${GITHUB_WORKSPACE}/.cache/owasp/dependency-check-data" >> $GITHUB_ENV
 
-    - name: Displaying important variables
+    - name: Seed Sonar cache from container image
+      id: sonar_seed
       shell: bash
       run: |
-        echo "github_pr_id = ${{ inputs.github_pr_id }}"
-
-    - name: Prepare Sonar cache directory
-      shell: bash
-      run: |
-        mkdir -p "${SONAR_CACHE_DIR}"
+        echo "seeded=false" >> $GITHUB_OUTPUT
+        if [[ -d /opt/sonar/cache ]]; then
+          mkdir -p "${SONAR_CACHE_DIR}"
+          cp -r /opt/sonar/cache/. "${SONAR_CACHE_DIR}/"
+          echo "Sonar cache seeded from container image ($(du -sh "${SONAR_CACHE_DIR}" | cut -f1))"
+          echo "seeded=true" >> $GITHUB_OUTPUT
+        else
+          echo "No pre-warmed Sonar cache found in container image, trying GitHub Actions cache fallback"
+        fi
 
     - name: Cache local Sonar data
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      if: ${{ steps.sonar_seed.outputs.seeded != 'true' }}
       with:
         path: ${{ env.SONAR_CACHE_DIR }}
-        key: v1-sonar-cache-${{ runner.os }}
-        restore-keys: |
-          v1-sonar-cache-
+        key: v1-sonar-cache
 
-    - name: Prepare OWASP cache directory
+    - name: Generate OWASP cache bucket
       shell: bash
       if: ${{ inputs.github_pr_id == '' }}
       run: |
-        mkdir -p "${OWASP_DATA_DIR}"
-
-    - name: Cache local OWASP Dependency-Check data
-      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        echo "OWASP_CACHE_WEEK=$(date -u +%G%V)" >> $GITHUB_ENV
+        
+    - name: Seed OWASP cache from container image
+      id: owasp_seed
+      shell: bash
       if: ${{ inputs.github_pr_id == '' }}
+      run: |
+        echo "seeded=false" >> $GITHUB_OUTPUT
+        if [[ -d /opt/owasp/dependency-check-data ]]; then
+          mkdir -p "${OWASP_DATA_DIR}"
+          cp -r /opt/owasp/dependency-check-data/. "${OWASP_DATA_DIR}/"
+          echo "OWASP cache seeded from container image ($(du -sh "${OWASP_DATA_DIR}" | cut -f1))"
+          echo "seeded=true" >> $GITHUB_OUTPUT
+        else
+          echo "No pre-warmed OWASP data found in container image, trying GitHub Actions cache fallback"
+        fi
+
+    - name: Cache local OWASP Dependency-Check data (fallback)
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      if: ${{ inputs.github_pr_id == '' && steps.owasp_seed.outputs.seeded != 'true' }}
       with:
         path: ${{ env.OWASP_DATA_DIR }}
-        key: v1-owasp-dependencies-${{ hashFiles('maven_cache_seed') }}
+        key: v1-owasp-dependencies-${{ env.OWASP_CACHE_WEEK }}
         restore-keys: |
           v1-owasp-dependencies-
 
@@ -144,15 +160,15 @@ runs:
         echo "GITHUB_SLUG: ${{ steps.vars.outputs.github_slug }}"
         echo "GITHUB_REF: ${GITHUB_REF}"
 
-    - name: Set common Sonar parameters
+    - name: OWASP Dependency-Check
       shell: bash
+      if: ${{ inputs.github_pr_id == '' }}
       run: |
-        SONAR_PARAMS="-DfailBuildOnCVSS=7 -DskipProvidedScope=true -DskipTestScope=true -DskipSystemScope=true -Dformats=HTML,JSON \
-          -Dsonar.dependencyCheck.jsonReportPath=target/dependency-check-report.json \
-          -Dsonar.dependencyCheck.htmlReportPath=target/dependency-check-report.html \
+        echo "Executing an OWASP analysis on branch: ${{ steps.vars.outputs.branch }}"
+        OWASP_PARAMS="-DfailBuildOnCVSS=7 -DskipProvidedScope=true -DskipTestScope=true -DskipSystemScope=true -Dformats=HTML,JSON \
           -DretireJsAnalyzerEnabled=false -DnodeAnalyzerEnabled=false -DassemblyAnalyzerEnabled=false -DnodeAuditSkipDevDependencies=true \
-          -DyarnAuditAnalyzerEnabled=false -Dsonar.userHome=${SONAR_USER_HOME} -DdataDirectory=${OWASP_DATA_DIR}"
-          
+          -DyarnAuditAnalyzerEnabled=false -DdataDirectory=${OWASP_DATA_DIR}"
+
         DEFAULT_SUPP="https://raw.githubusercontent.com/Jahia/jahia/master/.owasp/suppressions.xml"
         supps=("$DEFAULT_SUPP")
 
@@ -164,74 +180,54 @@ runs:
           echo "Custom suppression file not found at: $(pwd)/$CUSTOM_FILE"
         fi
 
-        SUPPRESSION_LIST="$(IFS=','; echo "${supps[*]}")"  
-          
-        SONAR_PARAMS+=" -DsuppressionFiles=${SUPPRESSION_LIST}"  
-          
+        SUPPRESSION_LIST="$(IFS=','; echo "${supps[*]}")"
+        OWASP_PARAMS+=" -DsuppressionFiles=${SUPPRESSION_LIST}"
+
         # Optional NVD parameters - datafeed and API key are complementary:
         # datafeed bootstraps/refreshes the bulk DB, API key fetches incremental deltas on top
         if [[ -n "${{ inputs.nvd_datafeed_url }}" ]]; then
-          SONAR_PARAMS+=" -DnvdDatafeedUrl=${{ inputs.nvd_datafeed_url }}"
+          OWASP_PARAMS+=" -DnvdDatafeedUrl=${{ inputs.nvd_datafeed_url }}"
         fi
         if [[ -n "${{ inputs.nvd_apikey }}" ]]; then
-          SONAR_PARAMS+=" -DnvdApiKey=${{ inputs.nvd_apikey }}"
+          OWASP_PARAMS+=" -DnvdApiKeyEnvironmentVariable=NVD_API_KEY"
         fi
         if [[ -n "${{ inputs.cisa_known_exploited_vuln_url }}" ]]; then
-          SONAR_PARAMS+=" -DknownExploitedUrl=${{ inputs.cisa_known_exploited_vuln_url }}"
+          OWASP_PARAMS+=" -DknownExploitedUrl=${{ inputs.cisa_known_exploited_vuln_url }}"
         fi
-        
-        if [[ -n "${{ inputs.oss_username }}" && -n "${{ inputs.oss_apitoken }}" ]]; then
-          SONAR_PARAMS+=" -DossIndexUsername=${{ inputs.oss_username }} -DossIndexPassword=${{ inputs.oss_apitoken }} \
-            -DossindexAnalyzerUrl=https://api.guide.sonatype.com -DossindexAnalyzerUseCache=true"
-        else    
-          SONAR_PARAMS+=" -DossindexAnalyzerEnabled=false"
-        fi  
-        
-        echo "SONAR_PARAMS=${SONAR_PARAMS}" >> $GITHUB_ENV
 
-    - name: Sonar OWASP
-      shell: bash
-      if: ${{ inputs.github_pr_id == '' }}
-      run: |
-        echo "Executing an OWASP analysis on branch: ${{ steps.vars.outputs.branch }}"
+        OSS_ARGS=""
+        if [[ -n "${{ inputs.oss_username }}" && -n "${{ inputs.oss_apitoken }}" ]]; then
+          OSS_ARGS="-DossIndexUsername=${{ inputs.oss_username }} -DossIndexPassword=${{ inputs.oss_apitoken }} -DossIndexAnalyzerUrl=https://api.guide.sonatype.com -DossIndexAnalyzerUseCache=true"
+        else
+          OSS_ARGS="-DossIndexAnalyzerEnabled=false"
+        fi
         mvn -B -s ${{ inputs.mvn_settings_filepath }} org.owasp:dependency-check-maven:12.2.1:aggregate \
-          $SONAR_PARAMS
+          $OWASP_PARAMS \
+          $OSS_ARGS
 
     - name: Sonar Release branch analysis
       shell: bash
       if: ${{ always() }}
       run: |
         echo "Pull request number: ${{ inputs.github_pr_id }}"
+        SONAR_SCAN_PARAMS="-Dsonar.userHome=${SONAR_USER_HOME} \
+          -Dsonar.dependencyCheck.jsonReportPath=target/dependency-check-report.json \
+          -Dsonar.dependencyCheck.htmlReportPath=target/dependency-check-report.html"
         if [[ ! -z "${{ inputs.github_pr_id }}" ]]; then
           echo "Executing a PR based analysis"
           mvn -B -s ${{ inputs.mvn_settings_filepath }} org.sonarsource.scanner.maven:sonar-maven-plugin:5.6.0.6792:sonar \
               -Dsonar.pullrequest.branch=$GITHUB_REF \
               -Dsonar.pullrequest.key=${{ inputs.github_pr_id }} \
               -Dsonar.pullrequest.base=${{ inputs.primary_release_branch }} \
-              -Dsonar.pullrequest.github.repository=${{ steps.vars.outputs.github_slug }}
+              -Dsonar.pullrequest.github.repository=${{ steps.vars.outputs.github_slug }} \
+              $SONAR_SCAN_PARAMS
         elif [[ ${{ steps.vars.outputs.branch }} == ${{ inputs.primary_release_branch }} ]]; then
           echo "Executing an analysis on the main branch"
           mvn -B -s ${{ inputs.mvn_settings_filepath }} org.sonarsource.scanner.maven:sonar-maven-plugin:5.6.0.6792:sonar \
-            $SONAR_PARAMS
+            $SONAR_SCAN_PARAMS
         else
           echo "Executing an analysis on branch: ${{ inputs.primary_release_branch }}"
           mvn -B -s ${{ inputs.mvn_settings_filepath }} org.sonarsource.scanner.maven:sonar-maven-plugin:5.6.0.6792:sonar \
             -Dsonar.branch.name=${{ inputs.primary_release_branch }} \
-            $SONAR_PARAMS
-        fi
-
-    - name: Display cache directories usage
-      shell: bash
-      if: ${{ always() }}
-      run: |
-        echo "HOME: ${HOME}"
-        echo "GITHUB_WORKSPACE: ${GITHUB_WORKSPACE}"
-        echo "SONAR_USER_HOME: ${SONAR_USER_HOME}"
-        echo "Sonar cache directory status"
-        du -sh "${SONAR_CACHE_DIR}" 2>/dev/null || true
-        find "${SONAR_CACHE_DIR}" -type f 2>/dev/null | wc -l || true
-        if [[ "${{ inputs.github_pr_id }}" == "" ]]; then
-          echo "OWASP cache directory status"
-          du -sh "${OWASP_DATA_DIR}" 2>/dev/null || true
-          find "${OWASP_DATA_DIR}" -type f 2>/dev/null | wc -l || true
+            $SONAR_SCAN_PARAMS
         fi

--- a/sonar-analysis/action.yml
+++ b/sonar-analysis/action.yml
@@ -86,7 +86,7 @@ runs:
     - name: Set environment variables from parameters and manifest within container image
       shell: bash
       run: |
-        DEPENDENCY_CHECK_MAVEN_PLUGIN_VERSION_DEFAULT="12.2.1"
+        DEPENDENCY_CHECK_MAVEN_PLUGIN_VERSION_DEFAULT="12.2.2"
         SONAR_MAVEN_PLUGIN_VERSION_DEFAULT="5.6.0.6792"
 
         DEPENDENCY_CHECK_MAVEN_PLUGIN_VERSION="${DEPENDENCY_CHECK_MAVEN_PLUGIN_VERSION_DEFAULT}"

--- a/sonar-analysis/action.yml
+++ b/sonar-analysis/action.yml
@@ -86,15 +86,12 @@ runs:
     - name: Set environment variables from parameters and manifest within container image
       shell: bash
       run: |
-        DEPENDENCY_CHECK_MAVEN_PLUGIN_VERSION_DEFAULT="12.2.2"
-        SONAR_MAVEN_PLUGIN_VERSION_DEFAULT="5.6.0.6792"
-
-        DEPENDENCY_CHECK_MAVEN_PLUGIN_VERSION="${DEPENDENCY_CHECK_MAVEN_PLUGIN_VERSION_DEFAULT}"
-        SONAR_MAVEN_PLUGIN_VERSION="${SONAR_MAVEN_PLUGIN_VERSION_DEFAULT}"
         if [[ -s /opt/jahia-sast-versions.env ]]; then
-          # Optional image-provided override; defaults above are used when file is absent.
           source /opt/jahia-sast-versions.env
         fi
+        # If versions couldn't be retrieved from the environment variable file above (coming from cache warmup container image), fallback to versions provided as default.
+        DEPENDENCY_CHECK_MAVEN_PLUGIN_VERSION=${DEPENDENCY_CHECK_MAVEN_PLUGIN_VERSION:-12.2.2}
+        SONAR_MAVEN_PLUGIN_VERSION=${SONAR_MAVEN_PLUGIN_VERSION:-5.6.0.6792}
 
         echo "SONAR_URL=${{ inputs.sonar_url }}" >> $GITHUB_ENV
         echo "SONAR_TOKEN=${{ inputs.sonar_token }}" >> $GITHUB_ENV

--- a/sonar-analysis/action.yml
+++ b/sonar-analysis/action.yml
@@ -83,11 +83,23 @@ runs:
       with:
         name: ${{ inputs.build_artifacts }}
 
-    - name: Set environment variables from parameters
+    - name: Set environment variables from parameters and manifest within container image
       shell: bash
       run: |
+        DEPENDENCY_CHECK_MAVEN_PLUGIN_VERSION_DEFAULT="12.2.1"
+        SONAR_MAVEN_PLUGIN_VERSION_DEFAULT="5.6.0.6792"
+
+        DEPENDENCY_CHECK_MAVEN_PLUGIN_VERSION="${DEPENDENCY_CHECK_MAVEN_PLUGIN_VERSION_DEFAULT}"
+        SONAR_MAVEN_PLUGIN_VERSION="${SONAR_MAVEN_PLUGIN_VERSION_DEFAULT}"
+        if [[ -s /opt/jahia-sast-versions.env ]]; then
+          # Optional image-provided override; defaults above are used when file is absent.
+          source /opt/jahia-sast-versions.env
+        fi
+
         echo "SONAR_URL=${{ inputs.sonar_url }}" >> $GITHUB_ENV
         echo "SONAR_TOKEN=${{ inputs.sonar_token }}" >> $GITHUB_ENV
+        echo "DEPENDENCY_CHECK_MAVEN_PLUGIN_VERSION=${DEPENDENCY_CHECK_MAVEN_PLUGIN_VERSION}" >> $GITHUB_ENV
+        echo "SONAR_MAVEN_PLUGIN_VERSION=${SONAR_MAVEN_PLUGIN_VERSION}" >> $GITHUB_ENV
         if [[ -n "${{ inputs.nvd_apikey }}" ]]; then
           echo "NVD_API_KEY=${{ inputs.nvd_apikey }}" >> $GITHUB_ENV
         fi
@@ -201,7 +213,7 @@ runs:
         else
           OSS_ARGS="-DossIndexAnalyzerEnabled=false"
         fi
-        mvn -B -s ${{ inputs.mvn_settings_filepath }} org.owasp:dependency-check-maven:12.2.1:aggregate \
+        mvn -B -s ${{ inputs.mvn_settings_filepath }} org.owasp:dependency-check-maven:${DEPENDENCY_CHECK_MAVEN_PLUGIN_VERSION}:aggregate \
           $OWASP_PARAMS \
           $OSS_ARGS
 
@@ -215,7 +227,7 @@ runs:
           -Dsonar.dependencyCheck.htmlReportPath=target/dependency-check-report.html"
         if [[ ! -z "${{ inputs.github_pr_id }}" ]]; then
           echo "Executing a PR based analysis"
-          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.sonarsource.scanner.maven:sonar-maven-plugin:5.6.0.6792:sonar \
+          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.sonarsource.scanner.maven:sonar-maven-plugin:${SONAR_MAVEN_PLUGIN_VERSION}:sonar \
               -Dsonar.pullrequest.branch=$GITHUB_REF \
               -Dsonar.pullrequest.key=${{ inputs.github_pr_id }} \
               -Dsonar.pullrequest.base=${{ inputs.primary_release_branch }} \
@@ -223,11 +235,11 @@ runs:
               $SONAR_SCAN_PARAMS
         elif [[ ${{ steps.vars.outputs.branch }} == ${{ inputs.primary_release_branch }} ]]; then
           echo "Executing an analysis on the main branch"
-          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.sonarsource.scanner.maven:sonar-maven-plugin:5.6.0.6792:sonar \
+          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.sonarsource.scanner.maven:sonar-maven-plugin:${SONAR_MAVEN_PLUGIN_VERSION}:sonar \
             $SONAR_SCAN_PARAMS
         else
           echo "Executing an analysis on branch: ${{ inputs.primary_release_branch }}"
-          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.sonarsource.scanner.maven:sonar-maven-plugin:5.6.0.6792:sonar \
+          mvn -B -s ${{ inputs.mvn_settings_filepath }} org.sonarsource.scanner.maven:sonar-maven-plugin:${SONAR_MAVEN_PLUGIN_VERSION}:sonar \
             -Dsonar.branch.name=${{ inputs.primary_release_branch }} \
             $SONAR_SCAN_PARAMS
         fi


### PR DESCRIPTION
### Description

Improve the cache and mirror handling of downloading data from 3rd party sources in Sonar and Dependency-Check.

We should make use the Sonar and Dependency-Check caches introduced in our ghcr.io/jahia/jahia-docker-mvn-cache containers. 

Enable again the OSS index analyzer cache (got temporarily disabled when switching to SonaType OSS Guide URL).

In the action the current caching fails, because sometimes a directory to cache did not exist. As Dependency-Check is only used on non-PR workflows, the Sonar and Dependency-Check caches should be kept independent. The local caches should only be used, if the action is not running within the ghcr.io/jahia/jahia-docker-mvn-cache container. 

For NVD data should use a community mirror datafeed as default. The datafeed is able to download only latest files from the mirror, which are not yet in the cache. The NVD API will then only load the very latest data from the NVD source server, which are not yet in the mirror. 

Replace the usage of the hashFiles cechekey part with an environment variable. Otherwise the hashFiles function is called a second time in the Post Run job, and in some tests it happened that the hash could not be produced correctly and consistent at that time. 

Also update to latest sonar and dependency-check plugin versions.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
