### PR TITLE
feat: Include tgz packages in maven build test artifacts

### DIFF
--- a/build-step-mvn/action.yml
+++ b/build-step-mvn/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: Copy dependencies to provision artifacts
     default: 'true'
     required: false
-  archive_only_jars:
+  archive_only_packages:
     description: Copy dependencies to provision artifacts
     default: 'false'
     required: false
@@ -72,7 +72,7 @@ runs:
         mvn -B -s $ROOT_PATH/${{ inputs.mvn_settings_filepath }} dependency:copy-dependencies -DexcludeTransitive=true -DincludeScope=provided -DincludeGroupIds=org.jahia.modules -DincludeTypes=jar
 
     - name: Archive build artifacts
-      if: ${{ inputs.archive_only_jars == 'false' }}
+      if: ${{ inputs.archive_only_packages == 'false' }}
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: ${{ inputs.github_artifact_name }}
@@ -82,10 +82,11 @@ runs:
         retention-days: ${{ inputs.github_artifact_retention }}
 
     - name: Archive build artifacts (.jars)
-      if: ${{ inputs.archive_only_jars == 'true' }}
+      if: ${{ inputs.archive_only_packages == 'true' }}
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: ${{ inputs.github_artifact_name }}
         path: |
           ${{ inputs.module_path }}**/target/*.jar
+          ${{ inputs.module_path }}**/target/*.tgz
         retention-days: ${{ inputs.github_artifact_retention }}

--- a/build-step-mvn/action.yml
+++ b/build-step-mvn/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: Copy dependencies to provision artifacts
     default: 'true'
     required: false
-  archive_only_packages:
+  archive_only_jar_and_tgz:
     description: Copy dependencies to provision artifacts
     default: 'false'
     required: false
@@ -72,7 +72,7 @@ runs:
         mvn -B -s $ROOT_PATH/${{ inputs.mvn_settings_filepath }} dependency:copy-dependencies -DexcludeTransitive=true -DincludeScope=provided -DincludeGroupIds=org.jahia.modules -DincludeTypes=jar
 
     - name: Archive build artifacts
-      if: ${{ inputs.archive_only_packages == 'false' }}
+      if: ${{ inputs.archive_only_jar_and_tgz == 'false' }}
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: ${{ inputs.github_artifact_name }}
@@ -82,7 +82,7 @@ runs:
         retention-days: ${{ inputs.github_artifact_retention }}
 
     - name: Archive build artifacts (.jars)
-      if: ${{ inputs.archive_only_packages == 'true' }}
+      if: ${{ inputs.archive_only_jar_and_tgz == 'true' }}
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: ${{ inputs.github_artifact_name }}

--- a/build/action.yml
+++ b/build/action.yml
@@ -64,7 +64,7 @@ runs:
       with:
         module_path: ${{ inputs.tests_module_path }}
         copy_dependencies: 'false'
-        archive_only_jars: 'true'
+        archive_only_packages: 'true'
         mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
         nexus_username: ${{ inputs.nexus_username }}
         nexus_password: ${{ inputs.nexus_password }}

--- a/build/action.yml
+++ b/build/action.yml
@@ -64,7 +64,7 @@ runs:
       with:
         module_path: ${{ inputs.tests_module_path }}
         copy_dependencies: 'false'
-        archive_only_packages: 'true'
+        archive_only_jar_and_tgz: 'true'
         mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
         nexus_username: ${{ inputs.nexus_username }}
         nexus_password: ${{ inputs.nexus_password }}


### PR DESCRIPTION
In jcontent PR, we have a multi-module pom structure in `tests/jahia-module` that contains both jar and tgz packages during build https://github.com/Jahia/jcontent/pull/2300/changes#diff-5e75dd1066e3aae583259b56f0d9f85c85e89bd43725b87225c2ae23dea6b902R83-R87:

```
    <modules>
        <module>jcontent-test-module</module>
        <module>jcontent-test-template</module>
        <module>jcontent-test-js-template</module>
  </modules>
```

This multimodule produces both jars and tgz artifacts. 

Since parent `jahia-module` is a mvn module, this executes the `build-step-mvn` with `archive_only_jars=true` and builds submodule artifacts https://github.com/Jahia/jahia-modules-action/blob/main/build/action.yml#L67. However tgz package does not get uploaded as a build test artifact https://github.com/Jahia/jahia-modules-action/blob/main/build-step-mvn/action.yml#L90 and is not accessible/installed during integration test execution. 

To fix, add tgz packages as part of archiving maven test module artifacts. Also to reflect this change, I've also renamed parameter from `archive_only_jars` to `archive_only_jar_and_tgz `. From my search, this is only used (set to true) for building maven test packages.