### PR TITLE
feat: add the ability to provide a registry when using maven-cache-warmup

### DIFF
--- a/maven-cache-warmup/README.md
+++ b/maven-cache-warmup/README.md
@@ -19,10 +19,11 @@ And use this instead:
 ```yaml
     runs-on: ubuntu-latest   
     steps:
-      - uses: jahia/jahia-modules-action/maven-cache-warmup@create-maven-cache-warmup
+      - uses: jahia/jahia-modules-action/maven-cache-warmup@v2
         with:
           docker-image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
-          username: ${{ secrets.GH_PACKAGES_USERNAME }}
-          password: ${{ secrets.GH_PACKAGES_TOKEN }}
+          docker-username: ${{ secrets.GH_PACKAGES_USERNAME }}
+          docker-password: ${{ secrets.GH_PACKAGES_TOKEN }}
+          docker-registry: ghcr.io
 ```
 

--- a/maven-cache-warmup/action.yml
+++ b/maven-cache-warmup/action.yml
@@ -7,11 +7,15 @@ inputs:
     required: true
     default: 'ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded'
   docker-username:
-    description: 'Docker login username'
+    description: Docker login username
     required: true
   docker-password:
-    description: 'Docker login password'
-    required: true    
+    description: Docker login password
+    required: true
+  docker-registry: 
+    description: Docker registry to log to (typically ghcr.io or docker.io)
+    required: false
+    default: 'ghcr.io'
   m2-path: 
     description: Path on the local instance for the .m2 folder
     required: false  
@@ -48,6 +52,7 @@ runs:
     - name: Docker login
       uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
       with:
+        registry: ${{ inputs.docker-registry }}
         username: ${{ inputs.docker-username }}
         password: ${{ inputs.docker-password }}
 


### PR DESCRIPTION
There were inconsistencies in the doc and support for registry, the image was on ghcr.io but there was no way to log into that registry in the action