### PR TITLE
feat: add optional VPN tunnel and Vault secrets steps

### DIFF
--- a/.github/workflows/reusable-integration-tests.yml
+++ b/.github/workflows/reusable-integration-tests.yml
@@ -107,6 +107,14 @@ on:
         type: boolean
         default: false
         description: "Enable Docker build cache using GitHub Actions cache to speed up Docker image builds"
+      vpn_enabled:
+        type: boolean
+        default: false
+        description: "Establish a WireGuard VPN tunnel before running the tests"
+      vault_secrets_enabled:
+        type: boolean
+        default: false
+        description: "Import secrets from HashiCorp Vault before running the tests"
 
 jobs:
   integration-tests:
@@ -136,6 +144,26 @@ jobs:
             echo "skip_notification=false" >> $GITHUB_OUTPUT
           fi       
 
+      - uses: jahia/jahia-modules-action/vpn-tunnel@v2
+        if: ${{ inputs.vpn_enabled }}
+        with:
+          config-base64: ${{ secrets.JC_WIREGUARD_VPN }}
+          canary-url: https://app.dev.j.jahia.com
+      - uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b #v3.4.0
+        if: ${{ inputs.vault_secrets_enabled }}
+        id: import-secrets
+        with:
+          url: ${{ vars.JC_VAULT_HOST }}
+          method: approle
+          tlsSkipVerify: true
+          roleId: ${{ secrets.JC_VAULT_ROLE_ID }}
+          secretId: ${{ secrets.JC_VAULT_SECRET_ID }}
+          secrets: |
+            kv/data/paas/frontend/aws access_key | JC_AWS_ACCESS_KEY ;
+            kv/data/paas/frontend/aws secret_key | JC_AWS_SECRET_KEY ;
+            kv/data/paas/frontend/jelastic master_login | JC_JELASTIC_MASTER_LOGIN ;
+            kv/data/paas/frontend/jelastic master_password | JC_JELASTIC_MASTER_PASSWORD ;
+            kv/data/paas/frontend/papi token | JC_PAPI_TOKEN
       - uses: jahia/jahia-modules-action/helper@v2
       - uses: KengoTODA/actions-setup-docker-compose@477353946803dd64eaa44008b865b6bfc88cab4e #v1.2.4
         with:

--- a/integration-tests/src/main.ts
+++ b/integration-tests/src/main.ts
@@ -221,11 +221,11 @@ async function run(): Promise<void> {
       }
     )
 
-    // Export containers artifacts (reports, secreenshots, videos)
+    // Export containers artifacts (reports, screenshots, videos)
     await core.group(
       `${timeSinceStart(
         startTime
-      )} 🐋 Export containers artifacts (reports, secreenshots, videos, logs) `,
+      )} 🐋 Export containers artifacts (reports, screenshots, videos, logs) `,
       async () => {
         await copyRunArtifacts(
           core.getInput('tests_container_name'),

--- a/vpn-tunnel/action.yml
+++ b/vpn-tunnel/action.yml
@@ -21,6 +21,31 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Check if running inside a Docker container
+      shell: bash
+      run: |
+        IN_CONTAINER=false
+
+        # Docker leaves this file in the root of the container filesystem
+        [ -f /.dockerenv ] && IN_CONTAINER=true
+
+        # Some runtimes set this environment variable (e.g. systemd-nspawn, LXC)
+        [ -n "${container:-}" ] && IN_CONTAINER=true
+
+        # cgroups v1: the hierarchy contains "docker", "kubepods", "containerd", etc.
+        # cgroups v2: a single-line file — non-empty path usually means a container
+        if grep -qE '(docker|containerd|kubepods|lxc|buildkit)' /proc/self/cgroup 2>/dev/null; then
+          IN_CONTAINER=true
+        fi
+
+        if [ "$IN_CONTAINER" = "true" ]; then
+          echo "❌ Running inside a container. The VPN tunnel action cannot configure kernel-level network interfaces from within a container."
+          echo "   Please run this action directly on the host runner."
+          exit 1
+        fi
+
+        echo "✅ Not running inside a container, proceeding with VPN tunnel setup."
+
     - name: Install Wireguard
       shell: bash
       run: |


### PR DESCRIPTION
### Description
This pull request adds new features to the integration test workflow, enabling optional setup of a WireGuard VPN tunnel and importing secrets from HashiCorp Vault. 

**Integration test workflow enhancements:**

* Added two new boolean inputs to `.github/workflows/reusable-integration-tests.yml`: `vpn_enabled` (to establish a WireGuard VPN tunnel) and `vault_secrets_enabled` (to import secrets from HashiCorp Vault before running tests).
* Integrated the `jahia/jahia-modules-action/vpn-tunnel@v2` step, which runs conditionally based on `vpn_enabled`, and the `hashicorp/vault-action` step, which runs conditionally based on `vault_secrets_enabled`, to set up the VPN and import required secrets, respectively.

**VPN tunnel action improvements:**

* Added a pre-check in `vpn-tunnel/action.yml` to detect if the action is running inside a container, and to abort with a clear error message if so, since VPN setup is not supported in containers.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
