### PR TITLE
fix: corrected a permission issue when setting up the VPN

### DIFF
--- a/.github/workflows/test-vpn-tunnel.yml
+++ b/.github/workflows/test-vpn-tunnel.yml
@@ -1,0 +1,73 @@
+# A Workflow to test the VPN tunnel on ubuntu-latest and self-hosted instances.
+# See 
+name: Test VPN tunnel
+
+on:
+  workflow_dispatch:
+
+jobs:
+  # Establish a VPN but tries to connect to a public URL
+  # This workflow should PASS
+  direct-ul-good-url:
+    runs-on: ubuntu-latest 
+    steps:
+      - uses: jahia/jahia-modules-action/vpn-tunnel@v2
+        with:
+          config-base64: ${{ secrets.JC_WIREGUARD_VPN }}
+          canary-url: https://www.github.com
+  
+  # Establish a VPN on "ubuntu-latest" and tries to connect to an invalid URL
+  # This workflow should FAIL
+  vpn-ul-wrong-url:
+    runs-on: ubuntu-latest 
+    steps:
+      - uses: jahia/jahia-modules-action/vpn-tunnel@v2
+        with:
+          config-base64: ${{ secrets.JC_WIREGUARD_VPN }}
+          canary-url: https://app.dev.j.rjahia.com
+
+  # Establish a VPN and tries to connect to an valid URL
+  # This workflow should PASS
+  vpn-ul-good-url:
+    runs-on: ubuntu-latest 
+    steps:
+      - uses: jahia/jahia-modules-action/vpn-tunnel@v2
+        with:
+          config-base64: ${{ secrets.JC_WIREGUARD_VPN }}
+          canary-url: https://app.dev.j.jahia.com
+
+  # Establish a VPN on "self-hosted" and tries to connect to an invalid URL
+  # This workflow should FAIL
+  vpn-sh-wrong-url:
+    runs-on: self-hosted
+    steps:
+      - uses: jahia/jahia-modules-action/vpn-tunnel@v2
+        with:
+          config-base64: ${{ secrets.JC_WIREGUARD_VPN }}
+          canary-url: https://app.dev.j.rjahia.com
+
+  # Establish a VPN on "self-hosted" and tries to connect to an valid URL
+  # This workflow should PASS
+  vpn-sh-good-url:
+    runs-on: self-hosted
+    steps:
+      - uses: jahia/jahia-modules-action/vpn-tunnel@v2
+        with:
+          config-base64: ${{ secrets.JC_WIREGUARD_VPN }}
+          canary-url: https://app.dev.j.jahia.com 
+
+  # Using self-hosted, runs the WF within a container
+  # This is not supported and known to not be working
+  # This workflow should FAIL
+  vpn-sh-good-url-container:
+    runs-on: self-hosted
+    container:
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
+      credentials:
+        username: ${{ secrets.GH_PACKAGES_USERNAME }}
+        password: ${{ secrets.GH_PACKAGES_TOKEN }} 
+    steps:
+      - uses: jahia/jahia-modules-action/vpn-tunnel@v2
+        with:
+          config-base64: ${{ secrets.JC_WIREGUARD_VPN }}
+          canary-url: https://app.dev.j.jahia.com            

--- a/vpn-tunnel/README.md
+++ b/vpn-tunnel/README.md
@@ -1,0 +1,53 @@
+# VPN Tunnel Action
+
+A composite GitHub Action to establish a WireGuard VPN tunnel on a runner.
+
+## Description
+
+This action sets up a WireGuard VPN tunnel using a base64-encoded configuration file. It supports both `ubuntu-latest` and `self-hosted` runners (but **not** containerized jobs).
+
+The action will:
+1. Verify it is **not** running inside a container (WireGuard requires kernel-level access)
+2. Install WireGuard and its dependencies
+3. Configure and bring up the VPN interface
+4. Optionally validate connectivity by calling a canary URL
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `config-base64` | A base64-encoded WireGuard configuration. Generate with `base64 -i wg0.conf -o -` | ✅ | — |
+| `canary-url` | A URL to validate the VPN connection. The action fails if the response code doesn't match `canary-http-response`. | ❌ | `''` |
+| `canary-http-response` | The expected HTTP status code when calling the canary URL | ❌ | `200` |
+| `canary-retries` | Number of retry attempts if the canary check fails | ❌ | `5` |
+
+## Usage
+
+```yaml
+steps:
+  - uses: jahia/jahia-modules-action/vpn-tunnel@v2
+    with:
+      config-base64: ${{ secrets.JC_WIREGUARD_VPN }}
+      canary-url: https://app.dev.j.jahia.com
+```
+
+## Limitations
+
+- **Cannot run inside a container.** The action requires direct access to the host's network stack to configure WireGuard interfaces. If it detects a container environment (Docker, LXC, containerd, etc.), it will exit with an error.
+
+## Testing
+
+A test workflow is available at `.github/workflows/test-vpn-tunnel.yml`. It can be **triggered manually** via `workflow_dispatch` from the Actions tab.
+
+The workflow contains multiple jobs covering different scenarios:
+
+| Job | Runner | Expected Result | Description |
+|-----|--------|-----------------|-------------|
+| `direct-ul-good-url` | `ubuntu-latest` | ✅ Pass | VPN up, validates against a public URL |
+| `vpn-ul-wrong-url` | `ubuntu-latest` | ❌ Fail | VPN up, canary points to an invalid URL |
+| `vpn-ul-good-url` | `ubuntu-latest` | ✅ Pass | VPN up, validates against an internal URL |
+| `vpn-sh-wrong-url` | `self-hosted` | ❌ Fail | VPN up on self-hosted, invalid canary URL |
+| `vpn-sh-good-url` | `self-hosted` | ✅ Pass | VPN up on self-hosted, valid canary URL |
+| `vpn-sh-good-url-container` | `self-hosted` (container) | ❌ Fail | Demonstrates that containerized runs are not supported |
+
+To trigger the test workflow, navigate to **Actions → Test VPN tunnel → Run workflow**.

--- a/vpn-tunnel/action.yml
+++ b/vpn-tunnel/action.yml
@@ -54,12 +54,14 @@ runs:
 
     - name: Create configuration file
       shell: bash
+      env:
+        WG_CONF_B64: ${{ secrets.WG_CONF_B64 }}
       run: |
-          echo "${{ inputs.config-base64 }}" |base64 -d > wg0.conf
-          sudo chmod 600 wg0.conf
-          ls -lah ./
           whoami
-          sudo wg-quick up ./wg0.conf
+          echo "$WG_CONF_B64" | base64 -d | sudo tee /etc/wireguard/wg0.conf > /dev/null
+          sudo chmod 600 /etc/wireguard/wg0.conf
+          sudo ls -lah /etc/wireguard/
+          sudo wg-quick up /etc/wireguard/wg0.conf
 
     - name: Validate connection using the provided canary URL
       shell: bash

--- a/vpn-tunnel/action.yml
+++ b/vpn-tunnel/action.yml
@@ -57,6 +57,8 @@ runs:
       run: |
           echo "${{ inputs.config-base64 }}" |base64 -d > wg0.conf
           sudo chmod 600 wg0.conf
+          ls -lah ./
+          whoami
           sudo wg-quick up ./wg0.conf
 
     - name: Validate connection using the provided canary URL

--- a/vpn-tunnel/action.yml
+++ b/vpn-tunnel/action.yml
@@ -55,7 +55,7 @@ runs:
     - name: Create configuration file
       shell: bash
       env:
-        WG_CONF_B64: ${{ secrets.WG_CONF_B64 }}
+        WG_CONF_B64: ${{ inputs.config-base64 }}
       run: |
           whoami
           echo "$WG_CONF_B64" | base64 -d | sudo tee /etc/wireguard/wg0.conf > /dev/null


### PR DESCRIPTION
Following some permissions issues, likely related to the upgrade to Ubuntu 26.04

Also included a WF that can be triggered manually to test the VPN connection