### PR TITLE
ci: add vault_host input in integration tests workflow

### DIFF
--- a/.github/workflows/reusable-integration-tests.yml
+++ b/.github/workflows/reusable-integration-tests.yml
@@ -115,6 +115,10 @@ on:
         type: boolean
         default: false
         description: "Import secrets from HashiCorp Vault before running the tests"
+      vault_host:
+        type: string
+        default: ""
+        description: "HashiCorp Vault host URL (e.g. https://vault.example.com). Required if vault_secrets_enabled is true."
 
 jobs:
   integration-tests:
@@ -153,7 +157,7 @@ jobs:
         if: ${{ inputs.vault_secrets_enabled }}
         id: import-secrets
         with:
-          url: ${{ vars.JC_VAULT_HOST }}
+          url: ${{ inputs.vault_host }}
           method: approle
           tlsSkipVerify: true
           roleId: ${{ secrets.JC_VAULT_ROLE_ID }}


### PR DESCRIPTION
### Description
This pull request updates the `reusable-integration-tests.yml` workflow to improve how the HashiCorp Vault host URL is configured for integration tests. The main change is to make the Vault host URL an explicit input parameter, rather than relying on a repository variable.

**Vault configuration improvements:**

* Added a new input parameter `vault_host` to the workflow, allowing the Vault host URL to be specified directly when running the workflow. This input is required if `vault_secrets_enabled` is true.
* Updated the job that imports secrets from Vault to use the `vault_host` input parameter instead of the `JC_VAULT_HOST` repository variable, ensuring more flexible and explicit configuration.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
