### PR TITLE
ci: add environment input on reusable integration tests

### DIFF
--- a/.github/workflows/reusable-integration-tests.yml
+++ b/.github/workflows/reusable-integration-tests.yml
@@ -119,9 +119,13 @@ on:
         type: string
         default: ""
         description: "HashiCorp Vault host URL (e.g. https://vault.example.com). Required if vault_secrets_enabled is true."
+      environment:
+        type: string
+        required: false
 
 jobs:
   integration-tests:
+    environment: ${{ inputs.environment }}
     name: Integration Tests
     runs-on: ${{ inputs.instance_type }}
     strategy:


### PR DESCRIPTION
### Description
This pull request updates the GitHub Actions workflow configuration to support running integration tests in a specified environment. The main change is the addition of an optional `environment` input, which allows the workflow to be associated with a GitHub environment for environment-specific settings or secrets.

Workflow improvements:

* Added an optional `environment` input to the `.github/workflows/reusable-integration-tests.yml` workflow, and configured the `integration-tests` job to use this input for GitHub environment selection.
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
