### PR TITLE
ci: add skip test input for sonar analysis

### DIFF
--- a/.github/workflows/reusable-sonar-scan.yml
+++ b/.github/workflows/reusable-sonar-scan.yml
@@ -69,6 +69,7 @@ jobs:
           mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+          skip_mvn_tests: 'true'
       - uses: jahia/jahia-modules-action/sonar-analysis@v2
         with:
           primary_release_branch: ${{ inputs.git_branch }}

--- a/build-step-mvn/action.yml
+++ b/build-step-mvn/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: 'Time during which artifact are kept in Github infrastructure'
     required: false
     default: '2'
+  skip_mvn_tests:
+    description: 'Skip tests execution during the build'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -71,7 +75,7 @@ runs:
       run: |
         ROOT_PATH=$(pwd)
         cd ${{ inputs.module_path }}
-        mvn -B -U -ntp -s $ROOT_PATH/${{ inputs.mvn_settings_filepath }} clean install
+        mvn -B -U -ntp -s $ROOT_PATH/${{ inputs.mvn_settings_filepath }} clean install -DskipTests=${{ inputs.skip_mvn_tests }}
 
     - name: Copy dependencies to provision artifacts
       if: ${{ inputs.copy_dependencies == 'true' }}

--- a/build/action.yml
+++ b/build/action.yml
@@ -38,6 +38,10 @@ inputs:
     description: 'Version of node to install on the host'
     required: false
     default: 'lts/*'
+  skip_mvn_tests:
+    description: 'Skip tests execution during the build of the MVN module'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -70,6 +74,7 @@ runs:
         nexus_password: ${{ inputs.nexus_password }}
         github_artifact_retention: ${{ inputs.github_artifact_retention }}
         github_artifact_name: build-artifacts-tests${{ inputs.github_artifact_suffix }}
+        skip_mvn_tests:  ${{ inputs.skip_mvn_tests }}
 
     - name: Check if test module is present (Javascript)
       if: ${{ inputs.tests_module_type == 'javascript' }}


### PR DESCRIPTION
### Description
This pull request introduces a new option to skip Maven tests during the build process across several GitHub Actions workflows. The main goal is to provide flexibility in CI/CD pipelines by allowing test execution to be toggled via an input parameter.

**Build and workflow enhancements:**

* Added a new `skip_mvn_tests` input to both `build-step-mvn/action.yml` and `build/action.yml`, allowing users to control whether Maven tests are executed during the build. [[1]](diffhunk://#diff-ce94dc2050959171254b8ad75da8b9cbe54462ecb32fb708297a1d39af15b638R37-R40) [[2]](diffhunk://#diff-5881ec64b771c47aba005f7a992b077a0d509f0acc5671b7576b1eb4714603f5R41-R44)
* Updated the Maven build command in `build-step-mvn/action.yml` to honor the `skip_mvn_tests` parameter by passing `-DskipTests=${{ inputs.skip_mvn_tests }}`.
* Passed the `skip_mvn_tests` input through the `build/action.yml` composite action to ensure the parameter is propagated to underlying build steps.
* Set `skip_mvn_tests: 'true'` in the Sonar scan workflow (`.github/workflows/reusable-sonar-scan.yml`) to skip tests during Sonar analysis builds.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
