### PR TITLE
ci: use skip_mvn_tests on build module instead of on test module

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -54,6 +54,7 @@ runs:
         nexus_password: ${{ inputs.nexus_password }}
         github_artifact_name: build-artifacts${{ inputs.github_artifact_suffix }}
         github_artifact_retention: ${{ inputs.github_artifact_retention }}
+        skip_mvn_tests: ${{ inputs.skip_mvn_tests }}
 
     - name: Check if test module is present (MVN)
       if: ${{ inputs.tests_module_type == 'mvn' }}
@@ -74,7 +75,6 @@ runs:
         nexus_password: ${{ inputs.nexus_password }}
         github_artifact_retention: ${{ inputs.github_artifact_retention }}
         github_artifact_name: build-artifacts-tests${{ inputs.github_artifact_suffix }}
-        skip_mvn_tests:  ${{ inputs.skip_mvn_tests }}
 
     - name: Check if test module is present (Javascript)
       if: ${{ inputs.tests_module_type == 'javascript' }}


### PR DESCRIPTION
### Description
This pull request makes a minor update to the `build/action.yml` workflow configuration. The main change is the addition of the `skip_mvn_tests` input to one of the build steps, ensuring that this parameter is correctly passed to the relevant step.

- Workflow configuration update:
  * Added the `skip_mvn_tests` input to the main build step to allow skipping Maven tests when specified.
  * Removed an extra space in the `skip_mvn_tests` input for the test build step for consistency.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
