### PR TITLE
ci: revert vault adding in integration tests workflow

### DIFF
--- a/.github/workflows/reusable-integration-tests.yml
+++ b/.github/workflows/reusable-integration-tests.yml
@@ -111,21 +111,9 @@ on:
         type: boolean
         default: false
         description: "Establish a WireGuard VPN tunnel before running the tests"
-      vault_secrets_enabled:
-        type: boolean
-        default: false
-        description: "Import secrets from HashiCorp Vault before running the tests"
-      vault_host:
-        type: string
-        default: ""
-        description: "HashiCorp Vault host URL (e.g. https://vault.example.com). Required if vault_secrets_enabled is true."
-      environment:
-        type: string
-        required: false
 
 jobs:
   integration-tests:
-    environment: ${{ inputs.environment }}
     name: Integration Tests
     runs-on: ${{ inputs.instance_type }}
     strategy:
@@ -157,21 +145,6 @@ jobs:
         with:
           config-base64: ${{ secrets.JC_WIREGUARD_VPN }}
           canary-url: https://app.dev.j.jahia.com
-      - uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b #v3.4.0
-        if: ${{ inputs.vault_secrets_enabled }}
-        id: import-secrets
-        with:
-          url: ${{ inputs.vault_host }}
-          method: approle
-          tlsSkipVerify: true
-          roleId: ${{ secrets.JC_VAULT_ROLE_ID }}
-          secretId: ${{ secrets.JC_VAULT_SECRET_ID }}
-          secrets: |
-            kv/data/paas/frontend/aws access_key | JC_AWS_ACCESS_KEY ;
-            kv/data/paas/frontend/aws secret_key | JC_AWS_SECRET_KEY ;
-            kv/data/paas/frontend/jelastic master_login | JC_JELASTIC_MASTER_LOGIN ;
-            kv/data/paas/frontend/jelastic master_password | JC_JELASTIC_MASTER_PASSWORD ;
-            kv/data/paas/frontend/papi token | JC_PAPI_TOKEN
       - uses: jahia/jahia-modules-action/helper@v2
       - uses: KengoTODA/actions-setup-docker-compose@477353946803dd64eaa44008b865b6bfc88cab4e #v1.2.4
         with:


### PR DESCRIPTION
### Description
This pull request simplifies the `reusable-integration-tests.yml` GitHub Actions workflow by removing all configuration and steps related to HashiCorp Vault secrets. The workflow no longer supports importing secrets from Vault, resulting in a cleaner and more straightforward configuration.

Workflow simplification:

* Removed all `vault_secrets_enabled`, `vault_host`, and `environment` input parameters, along with their descriptions and default values, from the workflow inputs section.
* Removed the entire step that used the `hashicorp/vault-action` to import secrets from HashiCorp Vault, including all related configuration and conditional logic.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
