### PR TITLE
fix: removed jahia-oauth from chachalog whitelist

### DIFF
--- a/chachalog-is-whitelisted/action.yml
+++ b/chachalog-is-whitelisted/action.yml
@@ -44,7 +44,6 @@ runs:
             'Jahia/forms-elasticsearch-storage-tests',
             'Jahia/jahia-docker-mvn-cache',
             'Jahia/jahia-modules-action',
-            'Jahia/jahia-oauth',
             'Jahia/jahia-qa',
             'Jahia/jahia-qa-data',
             'Jahia/jahia-reporter',


### PR DESCRIPTION
I suspect this was done by mistake, noticed this while doing changes in jahia-oauth.