### PR TITLE
feat: add reusable all-green gate workflow

### DIFF
--- a/.github/workflows/reusable-all-green.yml
+++ b/.github/workflows/reusable-all-green.yml
@@ -1,0 +1,98 @@
+# Reusable Workflow: All Checks Gate
+#
+# PURPOSE:
+#   Provides a single "gate" check that turns green only when every other
+#   check / status on the same commit has succeeded (or been skipped).
+#   This is useful as a branch-protection required status check so that
+#   you don't have to list every individual job — just require "gate".
+#
+# HOW IT WORKS:
+#   The workflow triggers on `check_suite` completions and `status` events.
+#   Each time a check finishes, this workflow re-evaluates all other checks
+#   and commit statuses for the same SHA:
+#     - If some checks are still running it exits neutrally (no failure).
+#     - If all checks completed successfully (or were skipped) it passes.
+#     - If any check failed it marks itself as failed.
+#   The job filters out its own check run ("gate") to avoid a self-reference
+#   loop.
+#
+# USAGE:
+#   In a consuming repository, create a workflow that calls this reusable
+#   workflow:
+#
+#     name: All Checks Gate
+#     on:
+#       check_suite:
+#         types: [completed]
+#       status: {}
+#
+#     jobs:
+#       all-green:
+#         uses: Jahia/jahia-modules-action/.github/workflows/reusable-all-green.yml@main
+#         secrets: inherit
+#
+#   Then add "gate" as the sole required status check in branch protection
+#   rules for your default branch.
+#
+# INPUTS: none
+# SECRETS: none (uses the default GITHUB_TOKEN)
+
+name: Reusable Workflow (All Checks Gate)
+
+on:
+  workflow_call:
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate all checks and statuses
+        uses: actions/github-script@f28e40c9614fd4ece07310c56374c1544014c6fb # v7.1.0
+        with:
+          script: |
+            const sha = context.sha;
+
+            const { data: combinedStatus } = await github.rest.repos.getCombinedStatusForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha,
+            });
+
+            const { data: checkRuns } = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha,
+              filter: 'latest',
+            });
+
+            // Exclude this workflow's own check to avoid self-reference loop
+            const otherChecks = checkRuns.check_runs.filter(
+              cr => cr.name !== 'gate'
+            );
+
+            const allCompleted = otherChecks.every(cr => cr.status === 'completed');
+            const allSuccess = otherChecks.every(
+              cr => cr.conclusion === 'success' || cr.conclusion === 'skipped'
+            );
+            const statusOk =
+              combinedStatus.state === 'success' || combinedStatus.statuses.length === 0;
+
+            if (!allCompleted) {
+              core.info('Not all checks completed yet — exiting neutrally (will re-trigger on next completion).');
+              return;
+            }
+
+            if (allSuccess && statusOk) {
+              core.info('All checks green!');
+            } else {
+              const failed = otherChecks
+                .filter(cr => cr.conclusion !== 'success' && cr.conclusion !== 'skipped')
+                .map(cr => `  - ${cr.name}: ${cr.conclusion}`);
+              if (failed.length > 0) {
+                core.info('Failed checks:\n' + failed.join('\n'));
+              }
+              if (combinedStatus.state !== 'success' && combinedStatus.statuses.length > 0) {
+                core.info(`Combined commit status: ${combinedStatus.state}`);
+              }
+              core.setFailed('Some checks failed or commit statuses are not green.');
+            }

--- a/.github/workflows/reusable-all-green.yml
+++ b/.github/workflows/reusable-all-green.yml
@@ -44,55 +44,11 @@ on:
 
 jobs:
   gate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
-      - name: Evaluate all checks and statuses
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - name: Checkout actions
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: All Green Gate
+        uses: ./delivery/all-green-gate
         with:
-          script: |
-            const sha = context.sha;
-
-            const { data: combinedStatus } = await github.rest.repos.getCombinedStatusForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: sha,
-            });
-
-            const { data: checkRuns } = await github.rest.checks.listForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: sha,
-              filter: 'latest',
-            });
-
-            // Exclude this workflow's own check to avoid self-reference loop
-            const otherChecks = checkRuns.check_runs.filter(
-              cr => cr.name !== 'gate'
-            );
-
-            const allCompleted = otherChecks.every(cr => cr.status === 'completed');
-            const allSuccess = otherChecks.every(
-              cr => cr.conclusion === 'success' || cr.conclusion === 'skipped'
-            );
-            const statusOk =
-              combinedStatus.state === 'success' || combinedStatus.statuses.length === 0;
-
-            if (!allCompleted) {
-              core.info('Not all checks completed yet — exiting neutrally (will re-trigger on next completion).');
-              return;
-            }
-
-            if (allSuccess && statusOk) {
-              core.info('All checks green!');
-            } else {
-              const failed = otherChecks
-                .filter(cr => cr.conclusion !== 'success' && cr.conclusion !== 'skipped')
-                .map(cr => `  - ${cr.name}: ${cr.conclusion}`);
-              if (failed.length > 0) {
-                core.info('Failed checks:\n' + failed.join('\n'));
-              }
-              if (combinedStatus.state !== 'success' && combinedStatus.statuses.length > 0) {
-                core.info(`Combined commit status: ${combinedStatus.state}`);
-              }
-              core.setFailed('Some checks failed or commit statuses are not green.');
-            }
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-all-green.yml
+++ b/.github/workflows/reusable-all-green.yml
@@ -10,11 +10,13 @@
 #   The workflow triggers on `check_suite` completions and `status` events.
 #   Each time a check finishes, this workflow re-evaluates all other checks
 #   and commit statuses for the same SHA:
-#     - If some checks are still running it exits neutrally (no failure).
+#     - If some checks are still running it fails (stays not-green) and will
+#       re-run on the next completion — this prevents a merge while the gate
+#       is the sole required check and other checks are still in flight.
 #     - If all checks completed successfully (or were skipped) it passes.
 #     - If any check failed it marks itself as failed.
-#   The job filters out its own check run ("gate") to avoid a self-reference
-#   loop.
+#   The job filters out its own check run (by run id) to avoid a
+#   self-reference loop.
 #
 # USAGE:
 #   In a consuming repository, create a workflow that calls this reusable

--- a/.github/workflows/reusable-all-green.yml
+++ b/.github/workflows/reusable-all-green.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate all checks and statuses
-        uses: actions/github-script@f28e40c9614fd4ece07310c56374c1544014c6fb # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const sha = context.sha;

--- a/.github/workflows/reusable-all-green.yml
+++ b/.github/workflows/reusable-all-green.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout actions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - name: All Green Gate
         uses: ./delivery/all-green-gate
         with:

--- a/delivery/all-green-gate/action.yml
+++ b/delivery/all-green-gate/action.yml
@@ -1,0 +1,66 @@
+name: All Green Gate
+description: >
+  Evaluates all check runs and commit statuses for the current SHA.
+  Passes only when every other check has succeeded or been skipped.
+  Exits neutrally (without failing) if checks are still in progress.
+
+inputs:
+  github_token:
+    description: 'GitHub personal API token'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Evaluate all checks and statuses
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      with:
+        github-token: ${{ inputs.github_token }}
+        retries: 3
+        script: |
+          const sha = context.sha;
+
+          const { data: combinedStatus } = await github.rest.repos.getCombinedStatusForRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: sha,
+          });
+
+          const { data: checkRuns } = await github.rest.checks.listForRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: sha,
+            filter: 'latest',
+          });
+
+          // Exclude this workflow's own check to avoid self-reference loop
+          const otherChecks = checkRuns.check_runs.filter(
+            cr => cr.name !== 'gate'
+          );
+
+          const allCompleted = otherChecks.every(cr => cr.status === 'completed');
+          const allSuccess = otherChecks.every(
+            cr => cr.conclusion === 'success' || cr.conclusion === 'skipped'
+          );
+          const statusOk =
+            combinedStatus.state === 'success' || combinedStatus.statuses.length === 0;
+
+          if (!allCompleted) {
+            core.info('Not all checks completed yet — exiting neutrally (will re-trigger on next completion).');
+            return;
+          }
+
+          if (allSuccess && statusOk) {
+            core.info('All checks green!');
+          } else {
+            const failed = otherChecks
+              .filter(cr => cr.conclusion !== 'success' && cr.conclusion !== 'skipped')
+              .map(cr => `  - ${cr.name}: ${cr.conclusion}`);
+            if (failed.length > 0) {
+              core.info('Failed checks:\n' + failed.join('\n'));
+            }
+            if (combinedStatus.state !== 'success' && combinedStatus.statuses.length > 0) {
+              core.info(`Combined commit status: ${combinedStatus.state}`);
+            }
+            core.setFailed('Some checks failed or commit statuses are not green.');
+          }

--- a/delivery/all-green-gate/action.yml
+++ b/delivery/all-green-gate/action.yml
@@ -1,12 +1,13 @@
 name: All Green Gate
 description: >
   Evaluates all check runs and commit statuses for the current SHA.
-  Passes only when every other check has succeeded or been skipped.
-  Exits neutrally (without failing) if checks are still in progress.
+  Passes only when every other check has completed and succeeded (or was
+  skipped). Fails (stays not-green) while any check is still in progress, so
+  it is safe to use as the sole required status check in branch protection.
 
 inputs:
   github_token:
-    description: 'GitHub personal API token'
+    description: 'GitHub token used to read check runs and commit statuses (the default GITHUB_TOKEN is sufficient).'
     required: true
 
 runs:
@@ -20,23 +21,34 @@ runs:
         script: |
           const sha = context.sha;
 
+          // The combined-status `state` is the rolled-up overall state across
+          // all commit statuses (independent of pagination), so a single call
+          // is authoritative for the pass/fail decision.
           const { data: combinedStatus } = await github.rest.repos.getCombinedStatusForRef({
             owner: context.repo.owner,
             repo: context.repo.repo,
             ref: sha,
           });
 
-          const { data: checkRuns } = await github.rest.checks.listForRef({
+          // Paginate: a single page (max 100) would silently drop checks on
+          // repos with many check runs and let the gate go green prematurely.
+          const allCheckRuns = await github.paginate(github.rest.checks.listForRef, {
             owner: context.repo.owner,
             repo: context.repo.repo,
             ref: sha,
             filter: 'latest',
           });
 
-          // Exclude this workflow's own check to avoid self-reference loop
-          const otherChecks = checkRuns.check_runs.filter(
-            cr => cr.name !== 'gate'
-          );
+          // Exclude this workflow's own check run to avoid a self-reference
+          // loop. As a reusable workflow the check is named "<caller-job> / gate"
+          // (not "gate"), so match on the current run id instead of the name;
+          // the name suffix is kept as a fallback.
+          const selfRunMarker = `/actions/runs/${context.runId}/`;
+          const isSelf = (cr) =>
+            (cr.details_url && cr.details_url.includes(selfRunMarker)) ||
+            cr.name === 'gate' ||
+            cr.name.endsWith('/ gate');
+          const otherChecks = allCheckRuns.filter(cr => !isSelf(cr));
 
           const allCompleted = otherChecks.every(cr => cr.status === 'completed');
           const allSuccess = otherChecks.every(
@@ -45,8 +57,20 @@ runs:
           const statusOk =
             combinedStatus.state === 'success' || combinedStatus.statuses.length === 0;
 
+          if (otherChecks.length === 0) {
+            core.info('No other check runs found for this SHA.');
+          }
+
+          // While anything is still running the gate must NOT be green, or a PR
+          // could be merged mid-flight when "gate" is the sole required check.
+          // It re-runs on each check/status completion and turns green once the
+          // final check finishes successfully.
           if (!allCompleted) {
-            core.info('Not all checks completed yet — exiting neutrally (will re-trigger on next completion).');
+            const pending = otherChecks
+              .filter(cr => cr.status !== 'completed')
+              .map(cr => `  - ${cr.name}: ${cr.status}`);
+            core.info('Checks still in progress:\n' + pending.join('\n'));
+            core.setFailed('Not all checks have completed yet — gate is not green.');
             return;
           }
 


### PR DESCRIPTION
## Summary

Adds a new reusable workflow (`.github/workflows/reusable-all-green.yml`) that provides a single "gate" check for branch protection.

## How it works

- Triggers via `workflow_call` (reusable workflow pattern)
- Evaluates all check runs and commit statuses for the current SHA
- Passes only when **all** other checks are completed and green (or skipped)
- Exits neutrally if checks are still in progress (avoids false failures)
- Excludes its own check run to prevent self-reference loops
- Logs which checks failed for easy debugging

## Usage

In a consuming repository:

```yaml
name: All Checks Gate
on:
  check_suite:
    types: [completed]
  status: {}

jobs:
  all-green:
    uses: Jahia/jahia-modules-action/.github/workflows/reusable-all-green.yml@main
    secrets: inherit
```

Then set `gate` as the sole required status check in branch protection rules.

## Security

All third-party actions are SHA-pinned for supply chain protection:
- `actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3` (v9.0.0)
- `actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0` (v6.0.3)
