### PR TITLE
chore(release): update CHANGELOG.md during release when present

### DIFF
--- a/.github/workflows/reusable-on-code-change.yml
+++ b/.github/workflows/reusable-on-code-change.yml
@@ -246,25 +246,33 @@ jobs:
     changelog:
       runs-on: ubuntu-latest
       steps:
-      - uses: dangoslen/changelog-enforcer@8b5e9dc3121363bb7c0115f8533404d92af382de # v3.7.0
-        id: changelog-enforcer
-        with:
-          skipLabels: '🗒%EF%B8%8F%20no-changelog,no-changelog'
-          missingUpdateErrorMessage: 'Please provide a changelog update'        
-          token: ${{ secrets.GH_API_TOKEN }}
-      - name: Delete the error comment
-        if: success()
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
-        with:
-          comment-tag: changelog-failed
-          mode: delete
-      - name: Comment on error
-        if: failure()
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
-        with:
-          message: |
-            Hey @${{ github.event.pull_request.user.login }}, the Changelog Enforcer failed. Can you take a look at the error below and correct it? Thanks!
-            ```
-            ${{ steps.changelog-enforcer.outputs.errorMessage }}
-            ```
-          comment-tag: changelog-failed
+        - name: Is repo whitelisted?
+          id: wl
+          uses: jahia/jahia-modules-action/changelog-is-whitelisted@v2
+          with:
+            repository: ${{ github.repository }}
+        - uses: dangoslen/changelog-enforcer@8b5e9dc3121363bb7c0115f8533404d92af382de # v3.7.0
+          if: ${{ steps.wl.outputs.whitelisted != 'true' }}
+          id: changelog-enforcer
+          with:
+            skipLabels: '🗒%EF%B8%8F%20no-changelog,no-changelog'
+            missingUpdateErrorMessage: 'Please provide a changelog update'        
+            token: ${{ secrets.GH_API_TOKEN }}
+        - name: Delete the error comment
+          if: ${{ steps.wl.outputs.whitelisted != 'true' }}
+          if: success()
+          uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+          with:
+            comment-tag: changelog-failed
+            mode: delete
+        - name: Comment on error
+          if: ${{ steps.wl.outputs.whitelisted != 'true' }}
+          if: failure()
+          uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+          with:
+            message: |
+              Hey @${{ github.event.pull_request.user.login }}, the Changelog Enforcer failed. Can you take a look at the error below and correct it? Thanks!
+              ```
+              ${{ steps.changelog-enforcer.outputs.errorMessage }}
+              ```
+            comment-tag: changelog-failed

--- a/.github/workflows/reusable-on-code-change.yml
+++ b/.github/workflows/reusable-on-code-change.yml
@@ -242,4 +242,29 @@ jobs:
               with:
                 nexus_username: ${{ secrets.NEXUS_USERNAME }}
                 nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-    
+
+    changelog:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: dangoslen/changelog-enforcer@8b5e9dc3121363bb7c0115f8533404d92af382de # v3.7.0
+        id: changelog-enforcer
+        with:
+          skipLabels: '🗒%EF%B8%8F%20no-changelog,no-changelog'
+          missingUpdateErrorMessage: 'Please provide a changelog update'        
+          token: ${{ secrets.GH_API_TOKEN }}
+      - name: Delete the error comment
+        if: success()
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          comment-tag: changelog-failed
+          mode: delete
+      - name: Comment on error
+        if: failure()
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          message: |
+            Hey @${{ github.event.pull_request.user.login }}, the Changelog Enforcer failed. Can you take a look at the error below and correct it? Thanks!
+            ```
+            ${{ steps.changelog-enforcer.outputs.errorMessage }}
+            ```
+          comment-tag: changelog-failed

--- a/.github/workflows/reusable-on-code-change.yml
+++ b/.github/workflows/reusable-on-code-change.yml
@@ -244,6 +244,9 @@ jobs:
                 nexus_password: ${{ secrets.NEXUS_PASSWORD }}
 
     changelog:
+      # The changelog enforcer (and the PR comment actions) only make sense
+      # in the context of a pull request
+      if: ${{ github.event_name == 'pull_request' }}
       runs-on: ubuntu-latest
       steps:
         - name: Is repo whitelisted?
@@ -255,19 +258,22 @@ jobs:
           if: ${{ steps.wl.outputs.whitelisted != 'true' }}
           id: changelog-enforcer
           with:
-            skipLabels: '🗒%EF%B8%8F%20no-changelog,no-changelog'
-            missingUpdateErrorMessage: 'Please provide a changelog update'        
+            skipLabels: '🗒️ no-changelog,no-changelog'
+            missingUpdateErrorMessage: |-
+              No CHANGELOG.md update was found in this pull request, please add an entry describing your change.
+              - Changes merged into the primary branch but not released yet belong to the "## Unreleased" section, at the top of the changelog.
+              - Keep a link to your pull request at the end of the entry, using the format: message (#PR-id)
+              - Take this opportunity to verify that the structure of the changelog is correct: released changes must be listed under the "## <version>" section corresponding to the version they were released with.
+              - Pay attention not to mix into the "## Unreleased" section changes that were already released in a previous version.
             token: ${{ secrets.GH_API_TOKEN }}
         - name: Delete the error comment
-          if: ${{ steps.wl.outputs.whitelisted != 'true' }}
-          if: success()
+          if: ${{ success() && steps.wl.outputs.whitelisted != 'true' }}
           uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
           with:
             comment-tag: changelog-failed
             mode: delete
         - name: Comment on error
-          if: ${{ steps.wl.outputs.whitelisted != 'true' }}
-          if: failure()
+          if: ${{ failure() && steps.wl.outputs.whitelisted != 'true' }}
           uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
           with:
             message: |

--- a/.github/workflows/reusable-release-module.yml
+++ b/.github/workflows/reusable-release-module.yml
@@ -127,7 +127,7 @@ jobs:
           echo "NEXUS_USERNAME=${{ steps.nexus-creds.outputs.NEXUS_USERNAME }}"
           echo "GITHUB_SLUG=${{ steps.slug.outputs.GITHUB_SLUG }}"
 
-      - uses: jahia/jahia-modules-action/release@65b02e7c1eebf68f1f5fa31864291de1f49767f1
+      - uses: jahia/jahia-modules-action/release@v2
         name: Release Module
         with:
           primary_release_branch: ${{ inputs.primary_release_branch }}

--- a/.github/workflows/reusable-release-module.yml
+++ b/.github/workflows/reusable-release-module.yml
@@ -127,7 +127,7 @@ jobs:
           echo "NEXUS_USERNAME=${{ steps.nexus-creds.outputs.NEXUS_USERNAME }}"
           echo "GITHUB_SLUG=${{ steps.slug.outputs.GITHUB_SLUG }}"
 
-      - uses: jahia/jahia-modules-action/release@eb9d1c15b12b02e68be32691efd1ae734e009045
+      - uses: jahia/jahia-modules-action/release@65b02e7c1eebf68f1f5fa31864291de1f49767f1
         name: Release Module
         with:
           primary_release_branch: ${{ inputs.primary_release_branch }}

--- a/.github/workflows/reusable-release-module.yml
+++ b/.github/workflows/reusable-release-module.yml
@@ -127,7 +127,7 @@ jobs:
           echo "NEXUS_USERNAME=${{ steps.nexus-creds.outputs.NEXUS_USERNAME }}"
           echo "GITHUB_SLUG=${{ steps.slug.outputs.GITHUB_SLUG }}"
 
-      - uses: jahia/jahia-modules-action/release@v2
+      - uses: jahia/jahia-modules-action/release@e7e9a9abf06515f92118ee9f650883be24d75fc5
         name: Release Module
         with:
           primary_release_branch: ${{ inputs.primary_release_branch }}

--- a/.github/workflows/reusable-release-module.yml
+++ b/.github/workflows/reusable-release-module.yml
@@ -127,7 +127,7 @@ jobs:
           echo "NEXUS_USERNAME=${{ steps.nexus-creds.outputs.NEXUS_USERNAME }}"
           echo "GITHUB_SLUG=${{ steps.slug.outputs.GITHUB_SLUG }}"
 
-      - uses: jahia/jahia-modules-action/release@e7e9a9abf06515f92118ee9f650883be24d75fc5
+      - uses: jahia/jahia-modules-action/release@eb9d1c15b12b02e68be32691efd1ae734e009045
         name: Release Module
         with:
           primary_release_branch: ${{ inputs.primary_release_branch }}

--- a/release/action.yml
+++ b/release/action.yml
@@ -210,6 +210,38 @@ runs:
         echo "final_release_version=${FINAL_RELEASE_VERSION}" >> $GITHUB_OUTPUT
         echo "tag_version=${TAG_VERSION}" >> $GITHUB_OUTPUT
 
+    - name: Update CHANGELOG.md for release (if present)
+      shell: bash
+      run: |
+        cd ${GITHUB_WORKSPACE}
+        if [[ -f "CHANGELOG.md" ]]; then
+          echo "Updating CHANGELOG.md for release version ${{ steps.versions.outputs.final_release_version }}"
+          RELEASE_VERSION="${{ steps.versions.outputs.final_release_version }}"
+          cp CHANGELOG.md CHANGELOG.md.bak
+
+          if grep -qE '^##[[:space:]]+Unreleased[[:space:]]*$' CHANGELOG.md; then
+            sed -E "0,/^##[[:space:]]+Unreleased[[:space:]]*$/s//## ${RELEASE_VERSION}/" CHANGELOG.md > CHANGELOG.md.tmp
+            {
+              echo "## Unreleased"
+              echo
+              cat CHANGELOG.md.tmp
+            } > CHANGELOG.md
+            rm -f CHANGELOG.md.tmp
+          else
+            {
+              echo "## Unreleased"
+              echo
+              cat CHANGELOG.md
+            } > CHANGELOG.md.tmp
+            mv CHANGELOG.md.tmp CHANGELOG.md
+          fi
+
+          rm -f CHANGELOG.md.bak
+          git add CHANGELOG.md
+        else
+          echo "No CHANGELOG.md found at repository root, skipping changelog update"
+        fi
+
     - name: Set version in pom file(s) for ${{ inputs.release_version }}
       shell: bash
       run: |
@@ -259,7 +291,7 @@ runs:
       shell: bash
       run: |
         cd ${GITHUB_WORKSPACE}
-        mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=${{ steps.versions.outputs.tag_version }} release:prepare -DreleaseVersion="${{ steps.versions.outputs.final_release_version }}" -DdevelopmentVersion="${{ steps.versions.outputs.next_development_version }}" -DscmCommentPrefix="[skip ci] [maven-release-plugin]"
+        mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=${{ steps.versions.outputs.tag_version }} release:prepare -DreleaseVersion="${{ steps.versions.outputs.final_release_version }}" -DdevelopmentVersion="${{ steps.versions.outputs.next_development_version }}" -DpushChanges=false
       env:
         GPG_KEY_PASSPHRASE: ${{ inputs.gpg_key_passphrase }}
 

--- a/release/action.yml
+++ b/release/action.yml
@@ -217,7 +217,6 @@ runs:
         if [[ -f "CHANGELOG.md" ]]; then
           echo "Updating CHANGELOG.md for release version ${{ steps.versions.outputs.final_release_version }}"
           RELEASE_VERSION="${{ steps.versions.outputs.final_release_version }}"
-          cp CHANGELOG.md CHANGELOG.md.bak
 
           if grep -qE '^##[[:space:]]+Unreleased[[:space:]]*$' CHANGELOG.md; then
             sed -E "0,/^##[[:space:]]+Unreleased[[:space:]]*$/s//## ${RELEASE_VERSION}/" CHANGELOG.md > CHANGELOG.md.tmp
@@ -236,8 +235,16 @@ runs:
             mv CHANGELOG.md.tmp CHANGELOG.md
           fi
 
-          rm -f CHANGELOG.md.bak
-          git add CHANGELOG.md
+          if ! git diff --quiet -- CHANGELOG.md; then
+            git add CHANGELOG.md
+            git commit -m "[skip ci] Update changelog for ${{ steps.versions.outputs.final_release_version }}"
+            if [[ ${{ inputs.sign_commits }} == 'true' ]]; then
+              git verify-commit $( git rev-parse HEAD )
+            fi
+            git push
+          else
+            echo "No CHANGELOG.md changes detected"
+          fi
         else
           echo "No CHANGELOG.md found at repository root, skipping changelog update"
         fi
@@ -291,7 +298,7 @@ runs:
       shell: bash
       run: |
         cd ${GITHUB_WORKSPACE}
-        mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=${{ steps.versions.outputs.tag_version }} release:prepare -DreleaseVersion="${{ steps.versions.outputs.final_release_version }}" -DdevelopmentVersion="${{ steps.versions.outputs.next_development_version }}" -DpushChanges=false
+        mvn -B -s ${{ inputs.mvn_settings_filepath }} -B -Dtag=${{ steps.versions.outputs.tag_version }} release:prepare -DreleaseVersion="${{ steps.versions.outputs.final_release_version }}" -DdevelopmentVersion="${{ steps.versions.outputs.next_development_version }}" -DscmCommentPrefix="[skip ci] [maven-release-plugin]"
       env:
         GPG_KEY_PASSPHRASE: ${{ inputs.gpg_key_passphrase }}
 

--- a/release/action.yml
+++ b/release/action.yml
@@ -145,7 +145,7 @@ runs:
       shell: bash
       run: |
         git fetch --all
-        git pull origin ${{ inputs.primary_release_branch }} --quiet
+        git pull origin ${{ inputs.primary_release_branch }} --quiet --rebase
 
     - name: Setup git
       shell: bash

--- a/release/action.yml
+++ b/release/action.yml
@@ -145,7 +145,7 @@ runs:
       shell: bash
       run: |
         git fetch --all
-        git pull origin ${{ inputs.primary_release_branch }} --quiet --rebase
+        git pull origin ${{ inputs.primary_release_branch }} --quiet
 
     - name: Setup git
       shell: bash
@@ -248,6 +248,8 @@ runs:
         else
           echo "No CHANGELOG.md found at repository root, skipping changelog update"
         fi
+      env:
+        GPG_KEY_PASSPHRASE: ${{ inputs.gpg_key_passphrase }}
 
     - name: Set version in pom file(s) for ${{ inputs.release_version }}
       shell: bash

--- a/release/action.yml
+++ b/release/action.yml
@@ -218,17 +218,20 @@ runs:
           echo "Updating CHANGELOG.md for release version ${{ steps.versions.outputs.final_release_version }}"
           RELEASE_VERSION="${{ steps.versions.outputs.final_release_version }}"
 
-          if grep -qE '^##[[:space:]]+Unreleased[[:space:]]*$' CHANGELOG.md; then
-            sed -E "0,/^##[[:space:]]+Unreleased[[:space:]]*$/s//## ${RELEASE_VERSION}/" CHANGELOG.md > CHANGELOG.md.tmp
-            {
-              echo "## Unreleased"
-              echo
-              cat CHANGELOG.md.tmp
-            } > CHANGELOG.md
-            rm -f CHANGELOG.md.tmp
+          if grep -qxF "## ${RELEASE_VERSION}" CHANGELOG.md; then
+            # Safety for re-executed releases: do not rotate the changelog twice
+            echo "CHANGELOG.md already contains a \"## ${RELEASE_VERSION}\" section, skipping update"
+          elif grep -qE '^##[[:space:]]+Unreleased[[:space:]]*$' CHANGELOG.md; then
+            # Rename the "## Unreleased" section into the release version and recreate an
+            # empty "## Unreleased" section right above it, keeping anything located
+            # before it (e.g. a "# Changelog" title) in place
+            sed -E "0,/^##[[:space:]]+Unreleased[[:space:]]*$/s//## Unreleased\n\n## ${RELEASE_VERSION}/" CHANGELOG.md > CHANGELOG.md.tmp
+            mv CHANGELOG.md.tmp CHANGELOG.md
           else
             {
               echo "## Unreleased"
+              echo
+              echo "## ${RELEASE_VERSION}"
               echo
               cat CHANGELOG.md
             } > CHANGELOG.md.tmp


### PR DESCRIPTION
### Description
Tested witht the sandbox (see https://github.com/Jahia/sandbox/blob/main/CHANGELOG.md)

The CHANGELOG update is requested with this job (to be added on PR workflow):
https://github.com/Jahia/sandbox/blob/main/.github/workflows/on-code-change.yml#L120-L144
PR for the reusable workflow: https://github.com/Jahia/jahia-modules-action/pull/387