### PR TITLE
feat: whitelist repos via the Changelog custom property

### DIFF
--- a/.github/workflows/reusable-chachalog-comment-pr.yml
+++ b/.github/workflows/reusable-chachalog-comment-pr.yml
@@ -20,6 +20,7 @@ jobs:
         uses: jahia/jahia-modules-action/changelog-is-whitelisted@v2
         with:
           repository: ${{ github.repository }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # If the repo does not contain a Chachalog config, this action
       # handles the creation of a default configuration, that should be

--- a/.github/workflows/reusable-chachalog-prepare-changelog.yml
+++ b/.github/workflows/reusable-chachalog-prepare-changelog.yml
@@ -20,6 +20,7 @@ jobs:
         uses: jahia/jahia-modules-action/changelog-is-whitelisted@v2
         with:
           repository: ${{ github.repository }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # If the repo does not contain a Chachalog config, this action
       # handles the creation of a default configuration, that should be

--- a/changelog-is-whitelisted/action.yml
+++ b/changelog-is-whitelisted/action.yml
@@ -1,14 +1,25 @@
 name: Is repository whitelisted for Chachalog
-description: Check if the provided repository is in the list of repositories to be whitelisted from changelog usage
+description: |
+  Check if the provided repository is whitelisted from changelog usage.
+
+  A repository is considered whitelisted when any of the following conditions are met:
+    1. The repository has a custom property named "Changelog" whose value is "false"
+    2. The repository is in the static whitelist maintained in this action
 
 inputs:
   repository:
     description: "Repository to check, using the format org/repo"
     required: true
     default: ""
+  github-token:
+    description: >-
+      Token used to read the repository custom properties
+      (requires "Metadata" read permission, granted by default to the workflow token).
+    required: false
+    default: ${{ github.token }}
 outputs:
   whitelisted:
-    description: '"true" if the repository is in the whitelist, otherwise "false".'
+    description: '"true" if the repository is whitelisted, otherwise "false".'
     value: ${{ steps.check.outputs.whitelisted }}
 
 runs:
@@ -18,10 +29,30 @@ runs:
       id: check
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       env:
-        INPUT_REPOSITORY: ${{ inputs.repository }}      
+        INPUT_REPOSITORY: ${{ inputs.repository }}
       with:
+        github-token: ${{ inputs.github-token }}
         script: |
           const inputRepo = process.env.INPUT_REPOSITORY?.trim();
+          const [owner, repo] = inputRepo.split('/');
+
+          // A repository can opt out of changelogs by setting the custom
+          // property "Changelog" to false. If the property is absent or set
+          // to true, the static whitelist below still applies.
+          try {
+            const { data: properties } = await github.request('GET /repos/{owner}/{repo}/properties/values', {
+              owner,
+              repo,
+            });
+            const changelogProperty = properties.find(p => p.property_name.toLowerCase() === 'changelog');
+            if (changelogProperty && String(changelogProperty.value).toLowerCase() === 'false') {
+              core.info(`Repository "${inputRepo}" has its "Changelog" custom property set to false, whitelisted: true`);
+              core.setOutput('whitelisted', 'true');
+              return;
+            }
+          } catch (error) {
+            core.warning(`Unable to read custom properties for "${inputRepo}" (${error.message}), falling back to the static whitelist.`);
+          }
 
           // Static whitelist (edit as needed)
           const whitelist = [

--- a/delivery/check-changelog/action.yml
+++ b/delivery/check-changelog/action.yml
@@ -4,7 +4,8 @@ description: |
 
   The check is skipped (passes) when any of the following conditions are met:
     1. The PR has a label containing "no" and "changelog" (e.g. "🗒️ no-changelog")
-    2. The repository is in the chachalog whitelist
+    2. The repository is whitelisted from changelogs (custom property
+       "Changelog" set to false, or listed in the static chachalog whitelist)
     3. ALL changed files match the changelog_exempt_paths patterns
        (e.g. only CI, tests, or docs were modified)
 
@@ -29,6 +30,13 @@ inputs:
       Default: ".github/**, tests/**, docker-tests/**, **/*.md"
     required: false
     default: ".github/**, tests/**, docker-tests/**, **/*.md"
+  github-token:
+    description: >-
+      Token used to read the repository custom properties when checking
+      the chachalog whitelist (requires "Metadata" read permission,
+      granted by default to the workflow token).
+    required: false
+    default: ${{ github.token }}
 
 runs:
   using: composite
@@ -55,6 +63,7 @@ runs:
       uses: jahia/jahia-modules-action/changelog-is-whitelisted@v2
       with:
         repository: ${{ github.repository }}
+        github-token: ${{ inputs.github-token }}
 
     - name: Do changed files require a changelog?
       id: check-paths-require-changelog


### PR DESCRIPTION
## Summary

Adds a new mechanism to whitelist a repository from changelog requirements, based on repository custom properties:

- If the repository has a custom property named `Changelog` whose value is `false`, it is considered whitelisted — no changelog required.
- If the property is set to `true` or is absent (or the custom properties API call fails), the check falls back to the existing static whitelist array, unchanged.

## Token handling

The custom properties lookup (`GET /repos/{owner}/{repo}/properties/values`) needs an API token. Rather than hardcoding one in the action step, the action exposes a new optional `github-token` input (defaulting to `${{ github.token }}`, the same pattern used by `actions/checkout` and `actions/github-script`), and the token is passed explicitly by all consumers in this repo:

- `.github/workflows/reusable-chachalog-prepare-changelog.yml`
- `.github/workflows/reusable-chachalog-comment-pr.yml`
- `delivery/check-changelog` (which gets its own optional `github-token` input, forwarded to the whitelist action)

The endpoint only requires `Metadata: read`, which every workflow `GITHUB_TOKEN` has, so no extra permissions are needed in consuming repos.

## Notes

- Backward compatible: the new inputs are optional with sensible defaults, and the `whitelisted` output format is unchanged (`"true"`/`"false"`).
- On custom properties API errors the action logs a warning and falls back to the static whitelist, so CI is not broken by a transient API failure.
- Actionlint may flag `github-token` as an invalid input on the `@v2` references until this change is merged and the `v2` tag is moved — expected.