### PR TITLE
fix(sonar): exclude src/test from main sources to avoid "indexed twice"

### DIFF
--- a/sonar-analysis/action.yml
+++ b/sonar-analysis/action.yml
@@ -235,6 +235,12 @@ runs:
       if: ${{ always() }}
       run: |
         echo "Pull request number: ${{ inputs.github_pr_id }}"
+        # `src/test` is test code by convention and must never be indexed as a main source. When
+        # sonar.sources includes a parent such as `src` that contains it (the default sonar_sources),
+        # the scanner indexes those files as both main and test and fails with
+        # "File ... can't be indexed twice". Always exclude the test source tree from the main source
+        # set so the two stay disjoint (harmless when sources/tests are unset or Maven-driven).
+        SONAR_EXCLUSIONS="${{ inputs.sonar_exclusions }},**/src/test/**"
         EXISTING_SOURCES=""
         IFS=',' read -ra SOURCE_PATHS <<< "${{ inputs.sonar_sources }}"
         for source_path in "${SOURCE_PATHS[@]}"; do
@@ -268,7 +274,7 @@ runs:
         fi
 
         SONAR_SCAN_PARAMS="-Dsonar.userHome=${SONAR_USER_HOME} \
-          -Dsonar.exclusions=${{ inputs.sonar_exclusions }} \
+          -Dsonar.exclusions=${SONAR_EXCLUSIONS} \
           -Dsonar.dependencyCheck.jsonReportPath=target/dependency-check-report.json \
           -Dsonar.dependencyCheck.htmlReportPath=target/dependency-check-report.html"
         if [[ "$IS_MULTI_MODULE" != "true" && -n "$EXISTING_SOURCES" ]]; then


### PR DESCRIPTION
## Problem

Since #381 the `sonar-analysis` action sets `sonar.sources` explicitly (default `src,resources,.github,pom.xml,package.json`). For a **single-module** Maven project (no `<modules>` in the root `pom.xml`), it passes both:

```
-Dsonar.sources=src,resources,.github,pom.xml,package.json
-Dsonar.tests=src/test,tests
```

`src` **contains** `src/test`, so every file under `src/test` is claimed by *both* the main and test file sets, and the scanner aborts:

```
File .../SomeTest.java can't be indexed twice. Please check that inclusion/exclusion
patterns produce disjoint sets for main and test files
```

This breaks Sonar analysis for **any single-module module with tests under `src/test`** that runs CI after #381 — e.g. [Jahia/content-versioning#149](https://github.com/Jahia/content-versioning/pull/149). Multi-module repos are unaffected (the action skips setting `sonar.sources`/`sonar.tests` there and lets Maven's per-module roots drive, which are already disjoint).

## Fix

`src/test` is test code by convention and must never be indexed as a *main* source. Always append `**/src/test/**` to `sonar.exclusions`, so those files are removed from the main source set while remaining test sources via `sonar.tests` → the two sets stay disjoint.

```diff
+        SONAR_EXCLUSIONS="${{ inputs.sonar_exclusions }},**/src/test/**"
         ...
-          -Dsonar.exclusions=${{ inputs.sonar_exclusions }} \
+          -Dsonar.exclusions=${SONAR_EXCLUSIONS} \
```

### Why this approach
- **Layout-agnostic** — works for Java (`src/main` + `src/test`) and JS modules whose sources sit directly under `src`; no need to special-case the source default (changing it to `src/main` would drop JS sources under `src`).
- **Applied in-script, unconditionally** — so a caller overriding `sonar_exclusions` can't accidentally re-introduce the overlap.
- **Safe everywhere** — no-op when sources/tests are unset or Maven-driven, and in multi-module builds (Maven already classifies `src/test/java` as tests). `sonar.exclusions` scopes only the *main* set; tests remain analyzed via `sonar.tests`/`sonar.test.exclusions`.
- Uses `**/src/test/**` (with `**/`) so it also covers sub-module paths.

## Note for reviewers
Please sanity-check the one assumption from your Sonar config knowledge: that adding `**/src/test/**` to `sonar.exclusions` removes those files from the **main** perimeter only (they stay declared as tests via `sonar.tests`). If you'd rather not touch exclusions, the alternative is defaulting `sonar_sources` to `src/main` for the Maven case — but that would miss JS sources placed directly under `src`.

🤖 Drafted with Claude Code.