### PR TITLE
chore(integration-tests): Increase timeout step default value

### DIFF
--- a/.github/workflows/reusable-integration-tests.yml
+++ b/.github/workflows/reusable-integration-tests.yml
@@ -46,7 +46,7 @@ on:
       skip_notifications:
         required: false
         type: boolean
-        default: false        
+        default: false
       pagerduty_incident_service:
         required: false
         type: string
@@ -62,7 +62,7 @@ on:
         default: 65
       timeout_step:
         type: number
-        default: 50
+        default: 60
       tests_profile:
         type: string
         default: ""


### PR DESCRIPTION
### Description
Increase the default value of the `timeout_step` parameter from 50 minutes to 60 minutes.

#### Context

jahia-ee repository has more and more tests and the overall time execution has consequently increased.
Now, it happens that the tests do not complete under 50 minutes: for instance the _Starting the Docker environment_ step of https://github.com/Jahia/jahia-ee/actions/runs/28770042452/job/85301991729 timeouts after 50 minutes, even if the tests were running fine and almost done:
```
  cypress    |   Running:  search/specialCharactersRichText.cy.ts                                        (51 of 56)
  cypress    | 
  cypress    | 
  cypress    |   Search on special characters in Rich Text
  cypress    |     ✓ GIVEN the text "I love Cachaça" indexed WHEN searching THEN the result should be the page with index 0 and should match (33065ms)
  cypress    |     ✓ GIVEN the text "Œil" indexed WHEN searching THEN the result should be the page with index 1 and should match
  cypress    |     ✓ GIVEN the text "Jalapeño" indexed WHEN searching THEN the result should be the page with index 2 and should match
  cypress    |     ✓ GIVEN the text "Naïve café" indexed WHEN searching THEN the result should be the page with index 3 and should match
  cypress    |     ✓ GIVEN the text "Zürich résumé" indexed WHEN searching THEN the result should be the page with index 4 and should match
  cypress    |     ✓ GIVEN the text "François Müller" indexed WHEN searching THEN the result should be the page with index 5 and should match
  cypress    |     ✓ GIVEN the text "São Paulo" indexed WHEN searching THEN the result should be the page with index 6 and should match
  cypress    |     ✓ GIVEN the text "Björk" indexed WHEN searching THEN the result should be the page with index 7 and should match
  cypress    |     ✓ GIVEN the text "Señorita" indexed WHEN searching THEN the result should be the page with index 8 and should match
  cypress    |     ✓ GIVEN the text "Pokémon" indexed WHEN searching THEN the result should be the page with index 9 and should match
  cypress    |     ✓ GIVEN the text "Crème brûlée" indexed WHEN searching THEN the result should be the page with index 10 and should match
  cypress    |     ✓ GIVEN the text "Piña colada" indexed WHEN searching THEN the result should be the page with index 11 and should match
  cypress    |     ✓ GIVEN the text "Straße" indexed WHEN searching THEN the result should be the page with index 12 and should match
  cypress    |     ✓ GIVEN the text "Åpfel" indexed WHEN searching THEN the result should be the page with index 13 and should match
  cypress    |     ✓ GIVEN the text "Mañana" indexed WHEN searching THEN the result should be the page with index 14 and should match
  cypress    |     ✓ GIVEN the text "Tête-à-tête" indexed WHEN searching THEN the result should be the page with index 15 and should match
  cypress    |     ✓ GIVEN the text "Niño pequeño" indexed WHEN searching THEN the result should be the page with index 16 and should match
  cypress    |     ✓ GIVEN the text "Coração" indexed WHEN searching THEN the result should be the page with index 17 and should match
  cypress    |     ✓ GIVEN the text "Château" indexed WHEN searching THEN the result should be the page with index 18 and should match
  cypress    |     ✓ GIVEN the text "Ñandú" indexed WHEN searching THEN the result should be the page with index 19 and should match
  cypress    |     ✓ GIVEN the text "Θεσσαλονίκη" indexed WHEN searching THEN the result should be the page with index 20 and should match
  cypress    |     ✓ GIVEN the text "Ελλάδα" indexed WHEN searching THEN the result should be the page with index 21 and should match
  cypress    | 
  cypress    | 
  cypress    |   22 passing (57s)
  cypress    | 
  cypress    | [mochawesome] Report JSON saved to /home/jahians/results/reports/cypress_050.json
  cypress    | 
  cypress    | 
  cypress    |   (Results)
  cypress    | 
  cypress    |   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  cypress    |   │ Tests:        22                                                                               │
  cypress    |   │ Passing:      22                                                                               │
  cypress    |   │ Failing:      0                                                                                │
  cypress    |   │ Pending:      0                                                                                │
  cypress    |   │ Skipped:      0                                                                                │
  cypress    |   │ Screenshots:  0                                                                                │
  cypress    |   │ Video:        false                                                                            │
  cypress    |   │ Duration:     57 seconds                                                                       │
  cypress    |   │ Spec Ran:     search/specialCharactersRichText.cy.ts                                           │
  cypress    |   └────────────────────────────────────────────────────────────────────────────────────────────────┘
  cypress    | 
  cypress    | 
  cypress    | ────────────────────────────────────────────────────────────────────────────────────────────────────
  cypress    |                                                                                                     
  cypress    |   Running:  security/rememberMeCookie.cy.ts                                               (52 of 56)
```

A similar step in [this run](https://github.com/Jahia/jahia-ee/actions/runs/28770042452/job/85301991673) (with MySQL 8.4 and not 8.0) took for instance 44 minutes.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
