### PR TITLE
chore: increased difference between job and step timeout

### DIFF
--- a/.github/workflows/reusable-integration-tests.yml
+++ b/.github/workflows/reusable-integration-tests.yml
@@ -59,7 +59,7 @@ on:
         description: "This input is deprecated, please use skip_notifications instead."
       timeout_job:
         type: number
-        default: 65
+        default: 75
       timeout_step:
         type: number
         default: 60


### PR DESCRIPTION
I noticed that a run failed https://github.com/Jahia/jahia-ee/actions/runs/29269746234/job/87029327015 without the action being able to collect the artifacts.

Before there was a delta of 15mn between timeout_job and timeout_step (i.e. it will give 15mn after a failed step to wrap up the execution, collect artifacts, ...).

As a first fix, I'm restoring that time difference, there might be a deeper problem though that could make https://github.com/Jahia/jahia-modules-action/blob/main/integration-tests/README.md#fix-issue-with-childspawn not effective.

This is a follow up to: https://github.com/Jahia/jahia-modules-action/pull/388