### PR TITLE
feat(mtls-tunnel): reach internal Jahia services through the IT mTLS bastion

### DIFF
--- a/.github/workflows/test-mtls-tunnel.yml
+++ b/.github/workflows/test-mtls-tunnel.yml
@@ -1,0 +1,149 @@
+# A workflow to test the mTLS tunnel action: nominal use, use inside a container, and the
+# three ways it is supposed to fail.
+#
+# PREREQUISITE, not met yet: the broker allowlists the OIDC claims of the CALLING repository,
+# and Jahia/jahia-modules-action is not on that list. Until IT adds it, these jobs cannot
+# reach the broker and the action is validated from an allowlisted consumer repository
+# instead. See mtls-tunnel/README.md.
+#
+# Also needs, on this repository:
+#   vars    CI_MTLS_CA_URL, CI_MTLS_BASTION   (the broker's coordinates, which move)
+#   secrets CI_STEP_ROOT, CI_SERVER_CA        (public CA certificates, secrets for convenience)
+#
+# The hosts, the canary and the bastion certificate name are written in plain here: they say
+# what this test targets, and reading the file should be enough to know that.
+name: Test mTLS tunnel
+
+on:
+  workflow_dispatch:
+
+jobs:
+  # Two hosts in one job, with a canary on each.
+  # This job should PASS
+  two-hosts:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: jahia/jahia-modules-action/mtls-tunnel@v2
+        with:
+          hosts: |
+            papi.dev.cloud-core.jahia.com
+            citizen.dev.cloud-core.jahia.com
+          ca-url: ${{ vars.CI_MTLS_CA_URL }}
+          bastion: ${{ vars.CI_MTLS_BASTION }}
+          server-name: ci-egress.jahia.com
+          audience: jahia-ci-egress
+          step-root: ${{ secrets.CI_STEP_ROOT }}
+          server-ca: ${{ secrets.CI_SERVER_CA }}
+          canary-url: https://papi.dev.cloud-core.jahia.com/healthcheck
+
+  # Same thing inside a container, which vpn-tunnel cannot do. A bare image has neither
+  # stunnel nor curl/jq/openssl, so this also covers the install step.
+  # This job should PASS
+  container:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:24.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: jahia/jahia-modules-action/mtls-tunnel@v2
+        with:
+          hosts: papi.dev.cloud-core.jahia.com
+          ca-url: ${{ vars.CI_MTLS_CA_URL }}
+          bastion: ${{ vars.CI_MTLS_BASTION }}
+          server-name: ci-egress.jahia.com
+          audience: jahia-ci-egress
+          step-root: ${{ secrets.CI_STEP_ROOT }}
+          server-ca: ${{ secrets.CI_SERVER_CA }}
+          canary-url: https://papi.dev.cloud-core.jahia.com/healthcheck
+
+  # Called twice in one job: the host already tunnelled is skipped, and the same host on a
+  # second port reuses its loopback address instead of taking a new one.
+  # This job should PASS
+  called-twice:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: jahia/jahia-modules-action/mtls-tunnel@v2
+        with:
+          hosts: papi.dev.cloud-core.jahia.com
+          ca-url: ${{ vars.CI_MTLS_CA_URL }}
+          bastion: ${{ vars.CI_MTLS_BASTION }}
+          server-name: ci-egress.jahia.com
+          audience: jahia-ci-egress
+          step-root: ${{ secrets.CI_STEP_ROOT }}
+          server-ca: ${{ secrets.CI_SERVER_CA }}
+
+      - uses: jahia/jahia-modules-action/mtls-tunnel@v2
+        with:
+          hosts: |
+            papi.dev.cloud-core.jahia.com
+            papi.dev.cloud-core.jahia.com:8443
+          ca-url: ${{ vars.CI_MTLS_CA_URL }}
+          bastion: ${{ vars.CI_MTLS_BASTION }}
+          server-name: ci-egress.jahia.com
+          audience: jahia-ci-egress
+          step-root: ${{ secrets.CI_STEP_ROOT }}
+          server-ca: ${{ secrets.CI_SERVER_CA }}
+
+  # The job does not grant id-token: write, which a composite action cannot grant itself.
+  # This job should FAIL, on the action's own error message rather than on a blank token.
+  no-oidc-permission:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: jahia/jahia-modules-action/mtls-tunnel@v2
+        with:
+          hosts: papi.dev.cloud-core.jahia.com
+          ca-url: ${{ vars.CI_MTLS_CA_URL }}
+          bastion: ${{ vars.CI_MTLS_BASTION }}
+          server-name: ci-egress.jahia.com
+          audience: jahia-ci-egress
+          step-root: ${{ secrets.CI_STEP_ROOT }}
+          server-ca: ${{ secrets.CI_SERVER_CA }}
+
+  # A malformed entry, caught by the action before anything is written to /etc/hosts.
+  # This job should FAIL
+  invalid-host:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: jahia/jahia-modules-action/mtls-tunnel@v2
+        with:
+          hosts: https://papi.dev.cloud-core.jahia.com
+          ca-url: ${{ vars.CI_MTLS_CA_URL }}
+          bastion: ${{ vars.CI_MTLS_BASTION }}
+          server-name: ci-egress.jahia.com
+          audience: jahia-ci-egress
+          step-root: ${{ secrets.CI_STEP_ROOT }}
+          server-ca: ${{ secrets.CI_SERVER_CA }}
+
+  # A host that is not in the bastion's target map: the tunnel comes up, but no traffic goes
+  # through it, so the canary is what catches it.
+  # This job should FAIL
+  denied-host:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: jahia/jahia-modules-action/mtls-tunnel@v2
+        with:
+          hosts: not-allowlisted.internal.example.com
+          ca-url: ${{ vars.CI_MTLS_CA_URL }}
+          bastion: ${{ vars.CI_MTLS_BASTION }}
+          server-name: ci-egress.jahia.com
+          audience: jahia-ci-egress
+          step-root: ${{ secrets.CI_STEP_ROOT }}
+          server-ca: ${{ secrets.CI_SERVER_CA }}
+          canary-url: https://not-allowlisted.internal.example.com/
+          canary-retries: 2

--- a/mtls-tunnel/README.md
+++ b/mtls-tunnel/README.md
@@ -1,0 +1,166 @@
+# mTLS Tunnel Action
+
+A composite GitHub Action that lets a CI job reach internal Jahia services using a short-lived client certificate minted from the run's own GitHub OIDC token.
+
+The tunnel carries **raw TCP**, so it is not limited to HTTPS: `ssh` on port 22 goes through it the same way `curl` does on 443.
+
+It replaces the WireGuard [`vpn-tunnel`](../vpn-tunnel) action for access to those services:
+
+| | `vpn-tunnel` (WireGuard) | `mtls-tunnel` |
+|---|---|---|
+| Credential | long-lived VPN configuration in a secret | the run's OIDC token, exchanged for a 1-hour certificate |
+| Concurrency | one shared peer, concurrent runs conflict | one identity per run |
+| Containers | not supported (kernel interface) | supported (userspace) |
+| Scope | whatever the VPN routes | only the hostnames allowlisted on the bastion |
+
+## Description
+
+The action installs `stunnel`, exchanges the run's OIDC token for a client certificate at the step-ca broker, then opens one mTLS tunnel per target `host:port` and maps each host to a loopback address in `/etc/hosts`.
+
+```
+local client  --plain traffic-->  127.0.0.x:<port>   (local stunnel client)
+                                  --mTLS, SNI=host-->  bastion
+                                  --raw TCP-->  <host>  (real service, real certificate)
+```
+
+The bastion routes on the outer SNI, then forwards raw TCP, which is why the payload is free. For a TLS payload, the client's own handshake travels *inside* the mTLS tunnel: there is no man-in-the-middle at the bastion, and tools keep verifying the real service certificate. No `-k`, no `--resolve`, no proxy variable, no per-tool configuration.
+
+Only hostnames present in the bastion's target map are forwarded; anything else is refused.
+
+## Requirements
+
+The calling job **must** declare the OIDC permission, since a composite action cannot grant it to itself:
+
+```yaml
+permissions:
+  id-token: write
+```
+
+The job also needs root (binding the loopback addresses and writing `/etc/hosts`): `sudo` on a GitHub-hosted runner, or running as root in a container job.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `hosts` | Hosts to tunnel, **one `host` or `host:port` per line**. Port defaults to 443. | ✅ | — |
+| `ca-url` | step-ca broker URL that signs the CSR, e.g. `https://<broker>:8444` | ✅ | — |
+| `bastion` | mTLS entry point of the bastion, `host:port` | ✅ | — |
+| `step-root` | step-ca root CA certificate, PEM. Public value. | ✅ | — |
+| `server-ca` | CA certificate of the bastion's server certificate, PEM. Public value. | ✅ | — |
+| `server-name` | Expected CN/SAN on the bastion certificate, pinned via `checkHost` | ✅ | — |
+| `audience` | `aud` claim requested for the OIDC token, the value the broker expects | ✅ | — |
+| `canary-url` | URLs fetched through the tunnels once they are up, **one per line**. Empty skips the check. | ❌ | `''` |
+| `canary-http-response` | Status code every canary URL must return. Empty accepts any HTTP response. | ❌ | `''` |
+| `canary-retries` | Attempts per canary URL before the check fails the job | ❌ | `5` |
+
+**No input describing the broker has a default.** `ca-url`, `bastion`, `server-name` and `audience` all identify one specific deployment, and baking any of them into the action would force a new release the day it moves. Pass them as organization variables. Only the canary inputs have defaults, and those are behaviour choices rather than environment values.
+
+`step-root` and `server-ca` are **public** CA certificates, not secrets; they sit in organization secrets for convenience only.
+
+### `hosts` and ports
+
+The port is the one your **local** tools connect to, and you rarely get to choose it: `ssh <host>` dials port 22 on its own, `curl https://<host>` dials 443. So it must be the target protocol's port, otherwise the tunnel listens somewhere the client never knocks and the connection is refused.
+
+### `audience`
+
+The `aud` claim of the OIDC token: who the token is meant for. GitHub signs a JWT saying "this run is `Jahia/<repo>` on such a ref", and the audience says "and it was minted for that broker". A token carrying anything else is refused, which is what stops a token obtained for another service (AWS, Vault...) from being replayed here, and vice versa.
+
+### `canary-url` and `canary-http-response`
+
+List one canary URL per tunnelled host: validating a single host would leave the other tunnels unproven, which is exactly what the canary exists to prevent.
+
+By default **any HTTP response counts as a success**, because what the canary proves is that the tunnel carried the request; only the absence of a response (`000`) means a broken tunnel. Set `canary-http-response` when you do want a strict code, and it then applies to every URL.
+
+Pick an endpoint that needs no authentication and has no side effect. Prefer a service's health endpoint, and prefer its shallowest form: a health check that also probes a database would fail your job for something the tunnel does perfectly well. This is the other reason the default accepts any response.
+
+Note that this differs from [`vpn-tunnel`](../vpn-tunnel), whose `canary-http-response` defaults to `200`.
+
+## Usage
+
+An HTTPS example, reaching two internal services in the same job:
+
+```yaml
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # required: the action cannot grant this to itself
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Open the mTLS tunnel
+        uses: jahia/jahia-modules-action/mtls-tunnel@v2
+        with:
+          hosts: |
+            registry.internal.example.com
+            api.internal.example.com
+          ca-url: ${{ vars.CI_MTLS_CA_URL }}
+          bastion: ${{ vars.CI_MTLS_BASTION }}
+          server-name: ${{ vars.CI_MTLS_SERVER_NAME }}
+          audience: ${{ vars.CI_MTLS_AUDIENCE }}
+          step-root: ${{ secrets.CI_STEP_ROOT }}
+          server-ca: ${{ secrets.CI_SERVER_CA }}
+          # optional: fail here rather than in the middle of the job
+          canary-url: |
+            https://registry.internal.example.com/health
+            https://api.internal.example.com/health
+
+      # From here on nothing is tunnel-specific: both hosts resolve to the tunnel.
+      - uses: hashicorp/setup-terraform@v3
+      - run: terraform init
+      - run: terraform plan
+```
+
+An SSH host works the same way. Only the port changes, and the canary does not apply:
+
+```yaml
+      - uses: jahia/jahia-modules-action/mtls-tunnel@v2
+        with:
+          hosts: build-host.internal.example.com:22
+          ca-url: ${{ vars.CI_MTLS_CA_URL }}
+          bastion: ${{ vars.CI_MTLS_BASTION }}
+          server-name: ${{ vars.CI_MTLS_SERVER_NAME }}
+          audience: ${{ vars.CI_MTLS_AUDIENCE }}
+          step-root: ${{ secrets.CI_STEP_ROOT }}
+          server-ca: ${{ secrets.CI_SERVER_CA }}
+
+      - run: ssh ci@build-host.internal.example.com 'uptime'
+```
+
+The tunnel only carries the connection: authenticating the SSH session itself (key, `known_hosts`) remains the caller's business.
+
+Two things to keep in mind:
+
+- **One call per job.** The tunnels live in the runner, not in the workflow: another job needing the same hosts calls the action again.
+- **The action can be called several times in one job**, for instance to add a host later on. Loopback addresses come from a job-wide counter, a host already tunnelled on that port is skipped, and a host reached on a second port reuses its address.
+
+## Testing
+
+A test workflow lives at `.github/workflows/test-mtls-tunnel.yml`, triggered manually from **Actions → Test mTLS tunnel → Run workflow**. As for [`vpn-tunnel`](../vpn-tunnel), some jobs are meant to fail: what matters is that each behaves as its column says.
+
+| Job | Expected | Covers |
+|-----|----------|--------|
+| `two-hosts` | ✅ Pass | Two hosts in one job, one canary each |
+| `container` | ✅ Pass | The same inside a bare container image, which `vpn-tunnel` cannot do |
+| `called-twice` | ✅ Pass | Second call skipping a tunnelled host, and a second port reusing its address |
+| `no-oidc-permission` | ❌ Fail | The job forgets `id-token: write`, and gets the action's own error |
+| `invalid-host` | ❌ Fail | A malformed entry, rejected before `/etc/hosts` is touched |
+| `denied-host` | ❌ Fail | A host outside the target map: the tunnel opens, no traffic passes |
+
+**It cannot run yet.** The broker allowlists the **calling** repository's OIDC claims, and `jahia-modules-action` is not on that list; asking IT for it is still to be done. Until then, the action is validated from a consumer repository that is already allowlisted, calling it by ref:
+
+```yaml
+- uses: jahia/jahia-modules-action/mtls-tunnel@<branch-or-tag>
+```
+
+Calling an external action does not change the claims presented to the broker, which is what makes both arrangements equivalent from its point of view.
+
+The workflow expects two variables (the broker's coordinates, which move) and the two CA certificates as secrets. The hosts it targets are written in plain in the file.
+
+## Limitations
+
+- **Hosts must be allowlisted on the bastion.** Adding a new host to a workflow requires an IT change on the target map first; until then the connection fails closed.
+- **The certificate lasts one hour and is not renewed in flight.** Jobs shorter than that are unaffected; a longer job would need a background renewal and a `stunnel` reload.
+- **No teardown.** Composite actions have no `post` step, so `stunnel` keeps running and the `/etc/hosts` entries remain until the runner is discarded. Fine on ephemeral runners; on a persistent self-hosted runner, clean up explicitly at the end of the job.
+- **The OIDC claims must match the broker's allowlist** (repository, and depending on the configuration the event and the ref). The action prints the claims it presents, so a rejection can be read directly against the allowlist.

--- a/mtls-tunnel/action.yml
+++ b/mtls-tunnel/action.yml
@@ -1,0 +1,330 @@
+name: mTLS Tunnel
+description: >
+  Reach internal Jahia services from CI over an mTLS tunnel, using a short-lived client
+  certificate minted from the run's GitHub OIDC token. Carries raw TCP, so HTTPS and ssh
+  alike work unmodified. Container-safe, one identity per run.
+
+# Network model:
+#
+#   local client  --its own protocol-->  127.0.0.x:<port>   (local stunnel client)
+#                                        --mTLS, SNI=host-->  bastion
+#                                        --raw TCP-->  <host>            (real service)
+#
+# The bastion routes on the outer SNI, then forwards raw TCP: it never terminates what the
+# client speaks, so a TLS payload still verifies the real service certificate and an ssh
+# session works just as well. See README.md for the rest.
+
+inputs:
+  hosts:
+    description: >
+      Internal hosts to tunnel, one `host` or `host:port` per line (a space- or
+      comma-separated list on a single line also works). The port is the one your tools
+      connect to locally, so use the target protocol's port: 443 (the default) for HTTPS,
+      22 for ssh. Each host must be allowlisted on IT's side; anything else is refused
+      (deny by default).
+    required: true
+  ca-url:
+    description: >
+      URL of the step-ca broker that exchanges the OIDC token for a client certificate,
+      e.g. "https://<broker>:8444". No default on purpose: the endpoint is environment
+      specific, and pinning it here would force a new action release when it moves.
+    required: true
+  bastion:
+    description: >
+      mTLS entry point of the egress bastion, as host:port, e.g. "<bastion>:8443". No
+      default, for the same reason as `ca-url`.
+    required: true
+  step-root:
+    description: >
+      step-ca root CA certificate, PEM. Public value (used as --cacert when talking to the
+      broker); store it as an organization secret or variable for convenience.
+    required: true
+  server-ca:
+    description: >
+      CA certificate that issued the bastion's server certificate, PEM. Public value, used
+      to verify the bastion at the outer TLS layer.
+    required: true
+  server-name:
+    description: >
+      Expected CN/SAN on the bastion's own certificate, pinned via stunnel's checkHost.
+      This is NOT the SNI the action sends: the SNI carries the target host (that is what
+      the bastion routes on), while the bastion certificate carries its own identity.
+      Requiring CN == SNI would fail by design. No default: it identifies one specific
+      bastion deployment.
+    required: true
+  audience:
+    description: >
+      Intended recipient of the GitHub OIDC token: the `aud` claim of the JWT, passed to
+      GitHub's token endpoint. The broker refuses a token minted for anything else, which
+      is what stops a token obtained for another service (AWS, Vault...) from being replayed
+      here. No default: the expected value belongs to the broker, not to this action.
+    required: true
+  canary-url:
+    description: >
+      Optional URLs fetched through the tunnels once they are up, one per line, so that a
+      broken tunnel fails here instead of in the middle of the job. List one per host to
+      cover them all. Empty (the default) skips the check.
+    required: false
+    default: ''
+  canary-http-response:
+    description: >
+      HTTP status code every canary URL must return. Empty (the default) accepts ANY HTTP
+      response: what the canary proves is that the tunnel carried the request, and a 403
+      from an unauthenticated endpoint proves that just as well as a 200: only the absence
+      of a response means a broken tunnel. Set a code to check it strictly.
+    required: false
+    default: ''
+  canary-retries:
+    description: Number of attempts per canary URL before the check fails the job.
+    required: false
+    default: '5'
+
+runs:
+  using: composite
+  steps:
+    - name: Install the tools the tunnel needs
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Root is needed (loopback binds, /etc/hosts): sudo on a hosted runner, nothing in a
+        # container where we already are root and sudo often is not installed.
+        if [ "$(id -u)" -eq 0 ]; then
+          SUDO=""
+        elif command -v sudo >/dev/null; then
+          SUDO="sudo"
+        else
+          echo "::error::This action needs root (privileged ports and /etc/hosts) but is running as $(id -un) without sudo."
+          exit 1
+        fi
+        echo "MTLS_SUDO=$SUDO" >> "$GITHUB_ENV"
+
+        # A hosted runner has everything but stunnel; a bare container image may have none of
+        # it. Hence installing what is actually missing rather than assuming.
+        missing=()
+        command -v stunnel >/dev/null || command -v stunnel4 >/dev/null || missing+=(stunnel4)
+        command -v curl    >/dev/null || missing+=(curl)
+        command -v jq      >/dev/null || missing+=(jq)
+        command -v openssl >/dev/null || missing+=(openssl)
+
+        if [ ${#missing[@]} -gt 0 ]; then
+          if ! command -v apt-get >/dev/null; then
+            echo "::error::Missing ${missing[*]} and no apt-get to install them. This action expects a Debian-based runner or image."
+            exit 1
+          fi
+          echo "Installing: ${missing[*]}"
+          $SUDO apt-get update -y
+          $SUDO DEBIAN_FRONTEND=noninteractive apt-get install -y "${missing[@]}"
+        fi
+
+    - name: Mint a short-lived client certificate from the run's OIDC token
+      shell: bash
+      env:
+        MTLS_CA_URL: ${{ inputs.ca-url }}
+        MTLS_AUDIENCE: ${{ inputs.audience }}
+        MTLS_STEP_ROOT: ${{ inputs.step-root }}
+        MTLS_SERVER_CA: ${{ inputs.server-ca }}
+      run: |
+        set -euo pipefail
+        # No `set -x` in this step: the JWT is a bearer credential.
+
+        # One working directory per invocation, so a job can call the action twice.
+        d="$RUNNER_TEMP/mtls-tunnel/${GITHUB_ACTION:-default}"
+        mkdir -p "$d"; chmod 700 "$d"
+        echo "MTLS_DIR=$d" >> "$GITHUB_ENV"
+
+        printf '%s\n' "$MTLS_STEP_ROOT" > "$d/step-root.crt"
+        printf '%s\n' "$MTLS_SERVER_CA" > "$d/server-ca.crt"
+
+        # A composite action cannot grant itself this permission: name the fix rather than
+        # fail later on an empty token.
+        if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+          echo "::error::No OIDC token available. Add 'permissions: { id-token: write }' to the job."
+          exit 1
+        fi
+
+        JWT=$(curl -fsSL -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+              "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=$MTLS_AUDIENCE" | jq -r '.value')
+
+        # Payload only, never the token: makes a rejection readable against the allowlist.
+        b=$(cut -d. -f2 <<<"$JWT" | tr '_-' '/+')
+        case $(( ${#b} % 4 )) in 2) b="$b==";; 3) b="$b=";; esac
+        echo "::group::OIDC claims presented to the broker"
+        base64 -d <<<"$b" | jq '{sub, aud, repository, repository_owner, ref, ref_type, base_ref, job_workflow_ref, event_name}'
+        echo "::endgroup::"
+
+        openssl req -newkey rsa:2048 -nodes \
+          -keyout "$d/client.key" -out "$d/client.csr" -subj "/CN=ci" >/dev/null 2>&1
+        chmod 600 "$d/client.key"
+
+        # --fail-with-body: on a 4xx (claims not allowlisted) the reason is in the body.
+        if ! resp=$(jq -n --arg csr "$(cat "$d/client.csr")" --arg ott "$JWT" '{csr:$csr, ott:$ott}' \
+                    | curl -sS --fail-with-body --cacert "$d/step-root.crt" \
+                        "$MTLS_CA_URL/1.0/sign" -H "Content-Type: application/json" -d @-); then
+          echo "::error::The broker refused to sign the CSR. See the claims above and its response below."
+          printf '%s\n' "$resp"
+          exit 1
+        fi
+        jq -r '.crt' <<<"$resp" >  "$d/client.crt"   # leaf
+        jq -r '.ca'  <<<"$resp" >> "$d/client.crt"   # + intermediate = full chain
+        chmod 600 "$d/client.crt"
+
+        echo "Client certificate obtained (one identity for the whole run):"
+        openssl x509 -in "$d/client.crt" -noout -subject -issuer -dates
+
+    - name: Open one mTLS tunnel per host
+      shell: bash
+      env:
+        MTLS_BASTION: ${{ inputs.bastion }}
+        MTLS_HOSTS: ${{ inputs.hosts }}
+        MTLS_SERVER_NAME: ${{ inputs.server-name }}
+      run: |
+        set -euo pipefail
+        d="$MTLS_DIR"
+        conf="$d/stunnel.conf"
+
+        cat > "$conf" <<EOF
+        foreground = no
+        pid = $d/stunnel.pid
+        output = $d/stunnel.log
+        debug = 4
+        EOF
+
+        # One loopback address per host: the port is imposed by the protocol, so hosts reached
+        # the same way all want the same one, and a port binds once per address. 127.0.0.0/8 is
+        # entirely local, so extra addresses are free.
+        counter="$RUNNER_TEMP/mtls-tunnel/.loopback-counter"
+        mkdir -p "$(dirname "$counter")"
+        [ -f "$counter" ] || echo 1 > "$counter"
+
+        # "host port ip" per line. Both files live outside the per-invocation directory, so a
+        # second call in the same job sees what the first opened.
+        opened_state="$RUNNER_TEMP/mtls-tunnel/.opened"
+        touch "$opened_state"
+
+        # Every action input is a string: word splitting handles both the multi-line and the
+        # single-line form, and `tr` keeps "a, b" from yielding a host named "a,".
+        opened=0
+        for entry in $(printf '%s' "$MTLS_HOSTS" | tr ',' ' '); do
+          # The port local tools connect to: 22 for ssh, 443 by default.
+          case "$entry" in
+            *:*) host="${entry%:*}"; port="${entry##*:}" ;;
+            *)   host="$entry";      port=443 ;;
+          esac
+
+          # Reject here: a bad entry would otherwise surface as a broken stunnel section.
+          if ! printf '%s' "$host" | grep -qE '^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$'; then
+            echo "::error::'$entry' is not a valid host[:port] entry. List one per line."
+            exit 1
+          fi
+          if ! printf '%s' "$port" | grep -qE '^[0-9]+$' || [ "$port" -lt 1 ] || [ "$port" -gt 65535 ]; then
+            echo "::error::'$entry' has an invalid port. Use host or host:port."
+            exit 1
+          fi
+
+          if grep -qE "^$host $port " "$opened_state"; then
+            echo "$host:$port: already tunnelled in this job, skipping"
+            continue
+          fi
+
+          # Same host on another port: reuse its address, one /etc/hosts mapping per host.
+          ip=$(awk -v h="$host" '$1 == h {print $3; exit}' "$opened_state")
+          if [ -z "$ip" ]; then
+            i=$(( $(cat "$counter") + 1 ))
+            echo "$i" > "$counter"
+            if [ "$i" -gt 254 ]; then
+              echo "::error::Ran out of loopback addresses (more than 253 tunnelled hosts)."
+              exit 1
+            fi
+            ip="127.0.0.$i"
+            # Unmodified tools reach the tunnel just by resolving the name.
+            echo "$ip $host" | ${MTLS_SUDO:-} tee -a /etc/hosts >/dev/null
+          fi
+
+          # Decoupled on purpose: `sni` is what the bastion routes on, `checkHost` pins the
+          # bastion's own certificate. Requiring CN == SNI would fail every tunnel.
+          cat >> "$conf" <<EOF
+
+        [${host}_${port}]
+        client = yes
+        accept = $ip:$port
+        connect = $MTLS_BASTION
+        cert = $d/client.crt
+        key = $d/client.key
+        CAfile = $d/server-ca.crt
+        verifyChain = yes
+        checkHost = $MTLS_SERVER_NAME
+        sni = $host
+        EOF
+          echo "$host $port $ip" >> "$opened_state"
+          echo "tunnel: $host:$port -> $ip:$port (outer SNI=$host) -> $MTLS_BASTION"
+          opened=$((opened + 1))
+        done
+
+        if [ "$opened" -eq 0 ]; then
+          echo "::error::No host to tunnel. Check the 'hosts' input."
+          exit 1
+        fi
+
+        # One process serves every section; binding privileged ports needs root.
+        ${MTLS_SUDO:-} stunnel "$conf"
+        sleep 2
+        if [ -f "$d/stunnel.pid" ] && ${MTLS_SUDO:-} kill -0 "$(${MTLS_SUDO:-} cat "$d/stunnel.pid")" 2>/dev/null; then
+          echo "✅ stunnel up with $opened tunnel(s)"
+        else
+          echo "::error::stunnel failed to start"
+          ${MTLS_SUDO:-} cat "$d/stunnel.log" 2>/dev/null || true
+          exit 1
+        fi
+
+    - name: Validate the egress with the canary URLs
+      shell: bash
+      env:
+        MTLS_CANARY_URL: ${{ inputs.canary-url }}
+        MTLS_CANARY_CODE: ${{ inputs.canary-http-response }}
+        MTLS_CANARY_RETRIES: ${{ inputs.canary-retries }}
+      run: |
+        set -uo pipefail
+        if [ -z "${MTLS_CANARY_URL//[[:space:]]/}" ]; then
+          echo "No canary URL provided, skipping the check."
+          exit 0
+        fi
+
+        rc=0
+        # One URL per line, like `hosts`: checking one host leaves the other tunnels unproven.
+        for url in $(printf '%s' "$MTLS_CANARY_URL" | tr ',' ' '); do
+          attempt=1; ok=0
+          while [ "$attempt" -le "$MTLS_CANARY_RETRIES" ]; do
+            # No -k, no --resolve: plain HTTPS has to work, certificate verification included.
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 25 "$url") || code=000
+            if [ -n "$MTLS_CANARY_CODE" ]; then
+              [ "$code" = "$MTLS_CANARY_CODE" ] && ok=1
+            else
+              # 000 = no response at all. Any code means the tunnel carried the request.
+              [ "$code" != "000" ] && ok=1
+            fi
+            if [ "$ok" -eq 1 ]; then
+              echo "✅ $url -> $code"
+              break
+            fi
+            echo "attempt $attempt/$MTLS_CANARY_RETRIES: $url -> $code"
+            attempt=$((attempt + 1))
+            [ "$attempt" -le "$MTLS_CANARY_RETRIES" ] && sleep 2
+          done
+          if [ "$ok" -eq 0 ]; then
+            if [ -n "$MTLS_CANARY_CODE" ]; then
+              echo "::error::canary $url never returned $MTLS_CANARY_CODE"
+            else
+              echo "::error::canary $url never answered: the tunnel did not carry the request"
+            fi
+            rc=1
+          fi
+        done
+
+        if [ "$rc" -ne 0 ]; then
+          echo "--- stunnel log ---"
+          ${MTLS_SUDO:-} cat "$MTLS_DIR/stunnel.log" 2>/dev/null | tail -40 || true
+        fi
+        exit $rc
+
+# No in-flight renewal: the certificate lasts an hour and today's jobs run well under that.
+# A longer job would need a background renewal plus a stunnel reload.


### PR DESCRIPTION
New composite action `mtls-tunnel`, which lets a CI job reach internal Jahia services without a VPN. The job's own GitHub OIDC token is exchanged for a one-hour client certificate at IT's step-ca broker, and one mTLS tunnel per target host is opened through their bastion. See [INFRA-3848](https://support.jahia.com/browse/INFRA-3848) for the IT side, Jahia/cloud-issues#6140 for ours.

It is meant to replace [`vpn-tunnel`](https://github.com/Jahia/jahia-modules-action/tree/main/vpn-tunnel) for these accesses, on its three limits:

| | `vpn-tunnel` (WireGuard) | `mtls-tunnel` |
|---|---|---|
| Credential | long-lived VPN config in a secret | the run's OIDC token, exchanged for a 1h certificate |
| Concurrency | one shared peer, concurrent runs conflict | one identity per run |
| Containers | unsupported (kernel interface) | supported (userspace) |

`vpn-tunnel` is left untouched: nothing migrates in this PR.

## What the caller sees

```yaml
    permissions:
      id-token: write   # the one thing a composite action cannot grant itself

    steps:
      - uses: jahia/jahia-modules-action/mtls-tunnel@v2
        with:
          hosts: |
            registry.internal.example.com
            api.internal.example.com
          ca-url: ${{ vars.CI_MTLS_CA_URL }}
          bastion: ${{ vars.CI_MTLS_BASTION }}
          server-name: ${{ vars.CI_MTLS_SERVER_NAME }}
          audience: ${{ vars.CI_MTLS_AUDIENCE }}
          step-root: ${{ secrets.CI_STEP_ROOT }}
          server-ca: ${{ secrets.CI_SERVER_CA }}

      - run: terraform plan   # unchanged: no -k, no --resolve, no proxy variable
```

The tunnel carries raw TCP, so the payload is not limited to HTTPS: an SSH host is reached by listing it as `host:22`.

Transparency is the point. Each host is mapped to its own loopback address in `/etc/hosts`, and a TLS payload's own handshake travels inside the tunnel, so tools keep verifying the real service certificate. Terraform, the papi provider and `vault` need no change.

No input describing the broker has a default: `ca-url`, `bastion`, `server-name` and `audience` all identify one specific deployment, and baking any of them in would force a release the day it moves. Only the canary inputs have defaults, and those are behaviour choices. `step-root` and `server-ca` are **public** CA certificates, not secrets; they sit in org secrets for convenience.

## Validation

Tested end to end from `cloud-ec-infra` (branch `test/cloud-core-egress`), which is already allowlisted. The test workflow belongs here in the end, next to the action as `test-vpn-tunnel.yml` is for `vpn-tunnel`; that needs IT to allowlist this repository's OIDC claims, which is still to be asked for. Calling an external action does not change the claims presented to the broker, so both arrangements are equivalent from its point of view.

- [run 30450561025](https://github.com/Jahia/cloud-ec-infra/actions/runs/30450561025): real HTTPS on `papi.dev` (`/healthcheck`) and `citizen.dev` (registry discovery), per-run identity `CN = Jahia/cloud-ec-infra:run-<id>`, certificate valid exactly one hour, two tunnels in one job.
- [run 30453527300](https://github.com/Jahia/cloud-ec-infra/actions/runs/30453527300): `host:port` syntax, a second call in the same job reusing a host's loopback address for a second port, and a host already tunnelled being skipped.
- [run 30459369349](https://github.com/Jahia/cloud-ec-infra/actions/runs/30459369349): same, with every broker input supplied by the caller.

Not covered: an SSH session end to end, since no SSH host is allowlisted for our claims. What is verified there is the control plane (parsing, allocation, a stunnel section on a port other than 443); the transport itself is what IT's own PoC does.
