### PR TITLE
feat: support mise.toml

### DIFF
--- a/.chachalog/mise-toolchain.md
+++ b/.chachalog/mise-toolchain.md
@@ -1,0 +1,8 @@
+---
+# Allowed version bumps: patch, minor, major
+jahia-modules-action: minor
+---
+
+Added support for `mise.toml`: modules that declare one now get their node **and yarn** versions from it, in static analysis, javascript builds, integration tests, Maven builds, releases and publications. Modules without a `mise.toml` are unaffected.
+
+If your module has a `mise.toml`, the `node_version`, `yarn_version` and `yarn_tests_version` inputs no longer apply and can be removed from your workflow — a warning is logged if you still pass a yarn version. Previously yarn came from whatever the runner happened to ship, or from a `yarnPath` committed inside the module, so the version used could change without notice.

--- a/.github/workflows/reusable-integration-tests.yml
+++ b/.github/workflows/reusable-integration-tests.yml
@@ -149,9 +149,6 @@ jobs:
       - uses: KengoTODA/actions-setup-docker-compose@477353946803dd64eaa44008b865b6bfc88cab4e #v1.2.4
         with:
           version: "1.29.2"
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: "lts/*"
       - uses: s4u/setup-maven-action@6c4e9964d4ecb8f1026310cd8618791fd51a8016 #v1.19.0
         with:
           java-distribution: ${{ inputs.mvn_java_distribution }}
@@ -159,6 +156,21 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           ref: ${{ inputs.module_branch }}
+
+      # Toolchain: mise.toml is the source of truth when the module has one, it pins both node
+      # and yarn. Modules without a mise.toml keep the legacy setup-node path below, which pins
+      # node only and leaves yarn to whatever the runner ships.
+      # NOTE: this must stay *after* the checkout, hashFiles() reads the working tree, so
+      # running it before checkout would always see an empty workspace and pick the fallback.
+      # TODO: once every module declares a mise.toml, delete the setup-node step.
+      - if: hashFiles('mise.toml') != ''
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+
+      - if: hashFiles('mise.toml') == ''
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "lts/*"
+
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
           module_id: ${{ inputs.module_id }}

--- a/.github/workflows/reusable-on-code-change.yml
+++ b/.github/workflows/reusable-on-code-change.yml
@@ -128,11 +128,7 @@ jobs:
         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
           with:
             ref: ${{ inputs.module_branch }}
-        # TEMPORARY, revert to @v2 before merging: the mise steps of this PR live in the
-        # composite actions, which @v2 does not carry yet, so a caller pinning this reusable
-        # workflow to the branch would still get the old toolchain. Lets
-        # https://github.com/Jahia/javascript-modules/pull/716 test the whole chain.
-        - uses: jahia/jahia-modules-action/static-analysis@chore/js-setup
+        - uses: jahia/jahia-modules-action/static-analysis@v2
           with:
             node_version: ${{ inputs.static_analysis_node_version }}
             auditci_level: ${{ inputs.static_analysis_auditci_level }}
@@ -150,8 +146,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:
                 ref: ${{ inputs.module_branch }}
-            # TEMPORARY, revert to @v2 before merging (see the static-analysis job above)
-            - uses: jahia/jahia-modules-action/build@chore/js-setup
+            - uses: jahia/jahia-modules-action/build@v2
               with:
                 mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
                 nexus_username: ${{ secrets.NEXUS_USERNAME }}
@@ -176,8 +171,7 @@ jobs:
         if: ${{ inputs.integration_tests_standalone_execute }}
         needs: build
         secrets: inherit
-        # TEMPORARY, revert to @v2 before merging (see the static-analysis job above)
-        uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@chore/js-setup
+        uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
         with:
             instance_type: ${{ inputs.integration_tests_instance_type }}
             module_id: ${{ inputs.module_id }}
@@ -201,8 +195,7 @@ jobs:
         if: ${{ inputs.integration_tests_cluster_execute }}
         needs: build
         secrets: inherit
-        # TEMPORARY, revert to @v2 before merging (see the static-analysis job above)
-        uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@chore/js-setup
+        uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
         with:
             instance_type: ${{ inputs.integration_tests_instance_type }}
             module_id: ${{ inputs.module_id }}
@@ -246,8 +239,7 @@ jobs:
                 password: ${{ secrets.GH_PACKAGES_TOKEN }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-            # TEMPORARY, revert to @v2 before merging (see the static-analysis job above)
-            - uses: jahia/jahia-modules-action/publish@chore/js-setup
+            - uses: jahia/jahia-modules-action/publish@v2
               with:
                 nexus_username: ${{ secrets.NEXUS_USERNAME }}
                 nexus_password: ${{ secrets.NEXUS_PASSWORD }}

--- a/.github/workflows/reusable-on-code-change.yml
+++ b/.github/workflows/reusable-on-code-change.yml
@@ -23,6 +23,7 @@ on:
         static_analysis_node_version:
             type: number
             default: 18
+            description: "DEPRECATED and ignored when the module has a mise.toml — declare node there instead."
         build_instance_type:
             type: string
             default: "ubuntu-latest"

--- a/.github/workflows/reusable-on-code-change.yml
+++ b/.github/workflows/reusable-on-code-change.yml
@@ -128,7 +128,11 @@ jobs:
         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
           with:
             ref: ${{ inputs.module_branch }}
-        - uses: jahia/jahia-modules-action/static-analysis@v2
+        # TEMPORARY, revert to @v2 before merging: the mise steps of this PR live in the
+        # composite actions, which @v2 does not carry yet, so a caller pinning this reusable
+        # workflow to the branch would still get the old toolchain. Lets
+        # https://github.com/Jahia/javascript-modules/pull/716 test the whole chain.
+        - uses: jahia/jahia-modules-action/static-analysis@chore/js-setup
           with:
             node_version: ${{ inputs.static_analysis_node_version }}
             auditci_level: ${{ inputs.static_analysis_auditci_level }}
@@ -146,7 +150,8 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:
                 ref: ${{ inputs.module_branch }}
-            - uses: jahia/jahia-modules-action/build@v2
+            # TEMPORARY, revert to @v2 before merging (see the static-analysis job above)
+            - uses: jahia/jahia-modules-action/build@chore/js-setup
               with:
                 mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
                 nexus_username: ${{ secrets.NEXUS_USERNAME }}
@@ -171,7 +176,8 @@ jobs:
         if: ${{ inputs.integration_tests_standalone_execute }}
         needs: build
         secrets: inherit
-        uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
+        # TEMPORARY, revert to @v2 before merging (see the static-analysis job above)
+        uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@chore/js-setup
         with:
             instance_type: ${{ inputs.integration_tests_instance_type }}
             module_id: ${{ inputs.module_id }}
@@ -195,7 +201,8 @@ jobs:
         if: ${{ inputs.integration_tests_cluster_execute }}
         needs: build
         secrets: inherit
-        uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
+        # TEMPORARY, revert to @v2 before merging (see the static-analysis job above)
+        uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@chore/js-setup
         with:
             instance_type: ${{ inputs.integration_tests_instance_type }}
             module_id: ${{ inputs.module_id }}
@@ -239,7 +246,8 @@ jobs:
                 password: ${{ secrets.GH_PACKAGES_TOKEN }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-            - uses: jahia/jahia-modules-action/publish@v2
+            # TEMPORARY, revert to @v2 before merging (see the static-analysis job above)
+            - uses: jahia/jahia-modules-action/publish@chore/js-setup
               with:
                 nexus_username: ${{ secrets.NEXUS_USERNAME }}
                 nexus_password: ${{ secrets.NEXUS_PASSWORD }}

--- a/build-step-javascript/action.yml
+++ b/build-step-javascript/action.yml
@@ -14,9 +14,10 @@ inputs:
     required: false
     default: ./
   node_version:
-    description: 'Version of node to install on the host'
+    description: 'Version of node to install on the host. DEPRECATED and ignored when the module has a mise.toml — declare node there instead.'
     required: false
     default: 'lts/*'
+    deprecationMessage: 'Use mise.toml'
   archive_artifacts:
     description: 'Should we archive built artifacts ?'
     default: 'true'
@@ -25,7 +26,17 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+    # Toolchain: mise.toml is the source of truth when the module has one, it pins both node
+    # and yarn. Modules without a mise.toml keep the legacy setup-node path below, which pins
+    # node only and leaves yarn to whatever the runner ships.
+    # NOTE: this must stay *after* the checkout, hashFiles() reads the working tree, so
+    # running it before checkout would always see an empty workspace and pick the fallback.
+    # TODO: once every module declares a mise.toml, delete the setup-node step.
+    - if: hashFiles('mise.toml') != ''
+      uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+
+    - if: hashFiles('mise.toml') == ''
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node_version }}
 

--- a/build-step-mvn/action.yml
+++ b/build-step-mvn/action.yml
@@ -70,6 +70,9 @@ runs:
         restore-keys: |
           ${{ runner.os }}-maven-
 
+    - if: hashFiles('mise.toml') != ''
+      uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+
     - name: Build package
       shell: bash
       run: |

--- a/build/action.yml
+++ b/build/action.yml
@@ -46,8 +46,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    # TEMPORARY, revert the three refs below to @v2 before merging: this action is the second
+    # @v2 hop between a caller and the mise steps this PR adds to build-step-mvn and
+    # build-step-javascript. Lets https://github.com/Jahia/javascript-modules/pull/716 test
+    # the whole chain.
     - name: Build package
-      uses: jahia/jahia-modules-action/build-step-mvn@v2
+      uses: jahia/jahia-modules-action/build-step-mvn@chore/js-setup
       with:
         mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
         nexus_username: ${{ inputs.nexus_username }}
@@ -64,7 +68,7 @@ runs:
         files: "${{ inputs.tests_module_path }}pom.xml"
 
     - name: Build tests package (MVN)
-      uses: jahia/jahia-modules-action/build-step-mvn@v2
+      uses: jahia/jahia-modules-action/build-step-mvn@chore/js-setup
       if: ${{ inputs.tests_module_type == 'mvn' && steps.check_test_module_mvn.outputs.files_exists == 'true' }}
       with:
         module_path: ${{ inputs.tests_module_path }}
@@ -85,7 +89,7 @@ runs:
 
     - name: Build tests package (javascript)
       if: ${{ inputs.tests_module_type == 'javascript' && steps.check_test_module_javascript.outputs.files_exists == 'true' }}
-      uses: jahia/jahia-modules-action/build-step-javascript@v2
+      uses: jahia/jahia-modules-action/build-step-javascript@chore/js-setup
       with:
         module_path: ${{ inputs.tests_module_path }}
         node_version: ${{ inputs.node_version }}

--- a/build/action.yml
+++ b/build/action.yml
@@ -46,12 +46,8 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    # TEMPORARY, revert the three refs below to @v2 before merging: this action is the second
-    # @v2 hop between a caller and the mise steps this PR adds to build-step-mvn and
-    # build-step-javascript. Lets https://github.com/Jahia/javascript-modules/pull/716 test
-    # the whole chain.
     - name: Build package
-      uses: jahia/jahia-modules-action/build-step-mvn@chore/js-setup
+      uses: jahia/jahia-modules-action/build-step-mvn@v2
       with:
         mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
         nexus_username: ${{ inputs.nexus_username }}
@@ -68,7 +64,7 @@ runs:
         files: "${{ inputs.tests_module_path }}pom.xml"
 
     - name: Build tests package (MVN)
-      uses: jahia/jahia-modules-action/build-step-mvn@chore/js-setup
+      uses: jahia/jahia-modules-action/build-step-mvn@v2
       if: ${{ inputs.tests_module_type == 'mvn' && steps.check_test_module_mvn.outputs.files_exists == 'true' }}
       with:
         module_path: ${{ inputs.tests_module_path }}
@@ -89,7 +85,7 @@ runs:
 
     - name: Build tests package (javascript)
       if: ${{ inputs.tests_module_type == 'javascript' && steps.check_test_module_javascript.outputs.files_exists == 'true' }}
-      uses: jahia/jahia-modules-action/build-step-javascript@chore/js-setup
+      uses: jahia/jahia-modules-action/build-step-javascript@v2
       with:
         module_path: ${{ inputs.tests_module_path }}
         node_version: ${{ inputs.node_version }}

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -56,6 +56,9 @@ runs:
         restore-keys: |
           ${{ runner.os }}-maven-
 
+    - if: hashFiles('mise.toml') != ''
+      uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+
     - name: Build package
       shell: bash
       run: mvn -B -s ${{ inputs.mvn_settings_filepath }} clean deploy -DskipTests -Dmaven.resolver.transport=wagon | tee mvnLogs.txt

--- a/release/action.yml
+++ b/release/action.yml
@@ -51,10 +51,6 @@ inputs:
   slack-webhook-qa:
     description: 'Secret webhook to send a notif on a QA channel'
     required: false
-  npmjs_publish_token:
-    description: 'Token used to publish javascript module (or any kind of npm package) to npmjs.com, typically used when the Maven release process delegates the package publication to npm'
-    default: ''
-    required: false
   sign_commits:
     description: 'Indicates if the release commits should be signed'
     default: 'false'
@@ -86,28 +82,11 @@ runs:
         echo "NEXUS_PASSWORD=${{ inputs.nexus_password }}" >> $GITHUB_ENV
         echo "NEXUS_RELEASE_USERNAME=${{ inputs.nexus_username }}" >> $GITHUB_ENV
         echo "NEXUS_RELEASE_PASSWORD=${{ inputs.nexus_password }}" >> $GITHUB_ENV
-        echo "NEXUS_RELEASE_PASSWORD=${{ inputs.npmjs_publish_token }}" >> $GITHUB_ENV
         # It is important that this environment variable always reflects the output of the tty command for all shell invocations (gpg-agent doc)
         echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
 
-    - name: Set npmjs.org auth token environment variable from parameter
-      if: ${{ inputs.npmjs_publish_token != '' }}
-      shell: bash
-      run: |
-        echo "NODE_AUTH_TOKEN=${{ inputs.npmjs_publish_token }}" >> $GITHUB_ENV
-
-    - name: Setup .npmrc file to publish to npmjs.org
-      if: ${{ inputs.npmjs_publish_token != '' }}
-      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-      with:
-        node-version: 'lts/*'
-        registry-url: 'https://registry.npmjs.org'
-
-    - name: Setup .yarnrc.yml file to allow publication to https://registry.npmjs.org with a 'yarn npm publish'
-      if: ${{ inputs.npmjs_publish_token != '' }}
-      shell: bash
-      run: |
-        echo "npmAuthToken: ${{ inputs.npmjs_publish_token }}" >> ~/.yarnrc.yml
+    - if: hashFiles('mise.toml') != ''
+      uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
 
     - name: Generate maven cache seed
       shell: bash

--- a/static-analysis/action.yml
+++ b/static-analysis/action.yml
@@ -21,14 +21,17 @@ inputs:
     description: 'Security level to check against for the tests codebase, will fail the step if higher'
     default: 'critical'
   node_version:
-    description: 'Version of node to install on the host'
+    description: 'Version of node to install on the host. DEPRECATED and ignored when the module has a mise.toml — declare node there instead.'
     default: 'lts/*'
+    deprecationMessage: 'Use mise.toml'
   yarn_version:
-    description: 'Version of Yarn to use for module'
+    description: 'Version of Yarn to use for module. DEPRECATED and ignored when the module has a mise.toml — declare yarn there instead.'
     required: false
+    deprecationMessage: 'Use mise.toml'
   yarn_test_version:
-    description: 'Version of Yarn to use for tests in module'
+    description: 'Version of Yarn to use for tests in module. DEPRECATED and ignored when the module has a mise.toml — declare yarn there instead.'
     required: false
+    deprecationMessage: 'Use mise.toml'
   skip_lint_modules:
     description: skip linter for modules when set to true
     type: boolean
@@ -49,7 +52,17 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+    # Toolchain: mise.toml is the source of truth when the module has one, it pins both node
+    # and yarn. Modules without a mise.toml keep the legacy setup-node path below, which pins
+    # node only and leaves yarn to whatever the runner ships.
+    # NOTE: this must stay *after* the checkout, hashFiles() reads the working tree, so
+    # running it before checkout would always see an empty workspace and pick the fallback.
+    # TODO: once every module declares a mise.toml, delete the setup-node step.
+    - if: hashFiles('mise.toml') != ''
+      uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+
+    - if: hashFiles('mise.toml') == ''
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node_version }}
 
@@ -61,7 +74,13 @@ runs:
         if [[ -d "${{ inputs.module_path }}" && -e "${{ inputs.module_path }}package.json" ]]; then
           cd ${{ inputs.module_path }}
           if [[ -n "${{ inputs.yarn_version }}" ]]; then
-            yarn set version ${{ inputs.yarn_version }}
+            if [[ -f "$GITHUB_WORKSPACE/mise.toml" ]]; then
+              # 'yarn set version' writes yarnPath into .yarnrc.yml and downloads a
+              # .yarn/releases/*.cjs — it would override the version mise just installed.
+              echo "::warning::yarn_version='${{ inputs.yarn_version }}' ignored: mise.toml pins yarn for this module"
+            else
+              yarn set version ${{ inputs.yarn_version }}
+            fi
           fi
           yarn
         fi
@@ -73,7 +92,11 @@ runs:
         if [[ -d "${{ inputs.tests_path }}" && -e "${{ inputs.tests_path }}package.json" ]]; then
           cd ${{ inputs.tests_path }}
           if [[ -n "${{ inputs.yarn_tests_version }}" ]]; then
-            yarn set version ${{ inputs.yarn_tests_version }}
+            if [[ -f "$GITHUB_WORKSPACE/mise.toml" ]]; then
+              echo "::warning::yarn_tests_version='${{ inputs.yarn_tests_version }}' ignored: mise.toml pins yarn for this module"
+            else
+              yarn set version ${{ inputs.yarn_tests_version }}
+            fi
           fi
           yarn
         fi
@@ -126,4 +149,3 @@ runs:
           audit-ci --${{ inputs.auditci_level_tests }}
         fi
         echo "::endgroup::"
-


### PR DESCRIPTION
If `mise.toml` exists, use [mise](https://mise.jdx.dev/) to download tools and skip other mechanisms 