### PR TITLE
ci: seed the AI incident triage workflow (dispatch registration)

### DIFF
--- a/.github/workflows/ai-incident-triage.yml
+++ b/.github/workflows/ai-incident-triage.yml
@@ -1,0 +1,115 @@
+# This workflow triages open "automated-incident" issues (nightly test failures) across the
+# whole organization, from this single repository: a deterministic job searches for issues whose
+# latest failure was not yet analyzed, then a Claude Code agent (running from the cortex harness,
+# reaching internal services through the IT mTLS bastion) analyzes each failed run's logs and
+# posts its conclusion as a comment on the issue. Analysis only — it never changes code.
+#
+# workflow_dispatch only: the mTLS broker mints certificates exclusively for
+# workflow_dispatch-triggered runs of this repository. Development iteration = dispatch the
+# feature branch (--ref) with search_scope narrowed to repo:Jahia/sandbox.
+name: AI Incident Triage
+
+on:
+  workflow_dispatch:
+    inputs:
+      search_scope:
+        description: "GitHub issue-search scope qualifier (e.g. org:Jahia, or repo:Jahia/sandbox)"
+        type: string
+        required: false
+        default: "org:Jahia"
+      dry_run:
+        description: "Only run issue selection; do not start the agent"
+        type: boolean
+        required: false
+        default: false
+      instance_type:
+        description: "Type of instances to run the agent job on"
+        type: string
+        required: false
+        default: "self-hosted"
+      timeout_job:
+        description: "Timeout (in minutes) of the agent job"
+        type: number
+        required: false
+        default: 60
+      cortex_ref:
+        description: "Git ref of the cortex harness to use"
+        type: string
+        required: false
+        default: "main"
+      claude_code_version:
+        description: "Claude Code CLI version to install"
+        type: string
+        required: false
+        default: "stable"
+      tunnel_hosts:
+        description: "Internal hosts to reach through the mTLS tunnel (space-separated); must be allowlisted on IT's side"
+        type: string
+        required: false
+        default: "litellm-prod.int.jahia.com qa.jahia.com"
+
+jobs:
+  select-issues:
+    name: Select incident issues
+    runs-on: ubuntu-slim
+    outputs:
+      issues: ${{ steps.select.outputs.issues }}
+      has_issues: ${{ steps.select.outputs.has_issues }}
+    steps:
+      - name: Select eligible incident issues
+        id: select
+        uses: jahia/jahia-modules-action/ai-incident-triage/select-issues@feat/ai-incident-triage
+        with:
+          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
+          search_scope: ${{ inputs.search_scope }}
+
+  triage:
+    name: Analyze incidents with Claude Code
+    needs: select-issues
+    if: needs.select-issues.outputs.has_issues == 'true' && !inputs.dry_run
+    runs-on: ${{ inputs.instance_type }}
+    timeout-minutes: ${{ inputs.timeout_job }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Open the mTLS tunnel to internal Jahia services
+        uses: jahia/jahia-modules-action/mtls-tunnel@feat/ai-incident-triage
+        with:
+          hosts: ${{ inputs.tunnel_hosts || 'litellm-prod.int.jahia.com qa.jahia.com' }}
+          ca-url: ${{ vars.INFRAJAHIA_MTLS_CA_URL }}
+          bastion: ${{ vars.INFRAJAHIA_MTLS_BASTION }}
+          server-name: ci-egress.jahia.com
+          audience: jahia-ci-egress
+          step-root: ${{ secrets.INFRAJAHIA_MTLS_STEP_ROOT }}
+          server-ca: ${{ secrets.INFRAJAHIA_MTLS_SERVER_CA }}
+          canary-url: ${{ vars.AI_LITELLM_BASE_URL }}/health/liveliness
+
+      - name: Set up Claude Code and the cortex harness
+        id: setup
+        uses: jahia/jahia-modules-action/ai-agent-setup@feat/ai-incident-triage
+        with:
+          claude_code_version: ${{ inputs.claude_code_version || 'stable' }}
+          anthropic_base_url: ${{ vars.AI_LITELLM_BASE_URL }}
+          anthropic_auth_token: ${{ secrets.AI_LITELLM_AUTH_TOKEN }}
+          default_opus_model: ${{ vars.AI_LITELLM_ANTHROPIC_DEFAULT_OPUS_MODEL }}
+          default_sonnet_model: ${{ vars.AI_LITELLM_ANTHROPIC_DEFAULT_SONNET_MODEL }}
+          default_haiku_model: ${{ vars.AI_LITELLM_ANTHROPIC_DEFAULT_HAIKU_MODEL }}
+          cortex_ref: ${{ inputs.cortex_ref || 'main' }}
+          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
+
+      - name: Triage the incident issues
+        id: triage
+        uses: jahia/jahia-modules-action/ai-incident-triage@feat/ai-incident-triage
+        with:
+          issues: ${{ needs.select-issues.outputs.issues }}
+          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
+          cortex_path: ${{ steps.setup.outputs.cortex_path }}
+
+      - name: Upload triage logs
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ai-incident-triage-logs
+          path: ${{ runner.temp }}/triage-logs
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Adds only `.github/workflows/ai-incident-triage.yml` to `main` so the workflow becomes registered for `workflow_dispatch` — GitHub cannot dispatch a workflow that exists solely on a branch, and the mTLS broker only mints certificates for dispatch-triggered runs of this repository (`denied: workflow_dispatch only`, see [run 31195252757](https://github.com/Jahia/jahia-modules-action/actions/runs/31195252757)).

## Why

Unblocks development iteration of [#393](https://github.com/Jahia/jahia-modules-action/pull/393): once registered, `gh workflow run ai-incident-triage.yml --ref feat/ai-incident-triage -f search_scope=repo:Jahia/sandbox` executes the branch's version end-to-end without touching real incidents.

## Notes

- The workflow references the new actions at `@feat/ai-incident-triage`; [#393](https://github.com/Jahia/jahia-modules-action/pull/393) flips everything to `@v2` before its final merge.
- Until #393 merges, a dispatch of the `main` version resolves the same branch actions — identical behavior.
- Defaults are safe to the extent that org-wide triage is the intended behavior; use `search_scope=repo:Jahia/sandbox` + `dry_run` for anything experimental.