### PR TITLE
docs(mtls-tunnel): fix the two stale variable names, drop the stale prerequisite

### DIFF
--- a/mtls-tunnel/README.md
+++ b/mtls-tunnel/README.md
@@ -53,7 +53,7 @@ The job also needs root (binding the loopback addresses and writing `/etc/hosts`
 | `canary-http-response` | Status code every canary URL must return. Empty accepts any HTTP response. | ❌ | `''` |
 | `canary-retries` | Attempts per canary URL before the check fails the job | ❌ | `5` |
 
-**No input describing the broker has a default.** `ca-url`, `bastion`, `server-name` and `audience` all identify one specific deployment, and baking any of them into the action would force a new release the day it moves. Pass them as organization variables. Only the canary inputs have defaults, and those are behaviour choices rather than environment values.
+**No input describing the broker has a default.** `ca-url`, `bastion`, `server-name` and `audience` all identify one specific deployment, and baking any of them into the action would force a new release the day it moves. Pass `ca-url` and `bastion` as organization variables; `server-name` and `audience` do not move, so callers write them in plain. Only the canary inputs have defaults, and those are behaviour choices rather than environment values.
 
 `step-root` and `server-ca` are **public** CA certificates, not secrets; they sit in organization secrets for convenience only.
 
@@ -97,8 +97,8 @@ jobs:
             api.internal.example.com
           ca-url: ${{ vars.INFRAJAHIA_MTLS_CA_URL }}
           bastion: ${{ vars.INFRAJAHIA_MTLS_BASTION }}
-          server-name: ${{ vars.CI_MTLS_SERVER_NAME }}
-          audience: ${{ vars.CI_MTLS_AUDIENCE }}
+          server-name: ci-egress.jahia.com
+          audience: jahia-ci-egress
           step-root: ${{ secrets.INFRAJAHIA_MTLS_STEP_ROOT }}
           server-ca: ${{ secrets.INFRAJAHIA_MTLS_SERVER_CA }}
           # optional: fail here rather than in the middle of the job
@@ -120,8 +120,8 @@ An SSH host works the same way. Only the port changes, and the canary does not a
           hosts: build-host.internal.example.com:22
           ca-url: ${{ vars.INFRAJAHIA_MTLS_CA_URL }}
           bastion: ${{ vars.INFRAJAHIA_MTLS_BASTION }}
-          server-name: ${{ vars.CI_MTLS_SERVER_NAME }}
-          audience: ${{ vars.CI_MTLS_AUDIENCE }}
+          server-name: ci-egress.jahia.com
+          audience: jahia-ci-egress
           step-root: ${{ secrets.INFRAJAHIA_MTLS_STEP_ROOT }}
           server-ca: ${{ secrets.INFRAJAHIA_MTLS_SERVER_CA }}
 
@@ -141,20 +141,13 @@ A test workflow lives at `.github/workflows/test-mtls-tunnel.yml`, triggered man
 
 | Job | Expected | Covers |
 |-----|----------|--------|
-| `two-hosts` | ✅ Pass | Two hosts in one job, one canary each |
+| `single-host` | ✅ Pass | One host with a canary |
+| `single-host-self-hosted` | ✅ Pass | The same on a self-hosted runner |
 | `container` | ✅ Pass | The same inside a bare container image, which `vpn-tunnel` cannot do |
 | `called-twice` | ✅ Pass | Second call skipping a tunnelled host, and a second port reusing its address |
 | `no-oidc-permission` | ❌ Fail | The job forgets `id-token: write`, and gets the action's own error |
 | `invalid-host` | ❌ Fail | A malformed entry, rejected before `/etc/hosts` is touched |
 | `denied-host` | ❌ Fail | A host outside the target map: the tunnel opens, no traffic passes |
-
-**It cannot run yet.** The broker allowlists the **calling** repository's OIDC claims, and `jahia-modules-action` is not on that list; asking IT for it is still to be done. Until then, the action is validated from a consumer repository that is already allowlisted, calling it by ref:
-
-```yaml
-- uses: jahia/jahia-modules-action/mtls-tunnel@<branch-or-tag>
-```
-
-Calling an external action does not change the claims presented to the broker, which is what makes both arrangements equivalent from its point of view.
 
 The workflow expects two variables (the broker's coordinates, which move) and the two CA certificates as secrets. The hosts it targets are written in plain in the file.
 


### PR DESCRIPTION
README hygiene only, no change to the action or to the test workflow.

Three things:

- **The two stale variable names.** #394 renamed four of the six to `INFRAJAHIA_MTLS_*` and left `server-name` and `audience` on `vars.CI_MTLS_*`. Neither name is defined on the organization (I checked all six from a run: only the four renamed ones resolve), so the documented example passes empty strings on two required inputs, and the job then fails on the handshake rather than on a missing variable. Those two values do not move, so the example writes them in plain, like the test workflow already does.
- **The "it cannot run yet" caveat is gone.** The repository is allowlisted at the broker: a `workflow_dispatch` run on a branch obtained a signed certificate on 07/08/2026, so neither the ref nor the event narrows it further. The consumer-repository workaround goes with it.
- **The job table follows the jobs #394 renamed and added.**

Three points on the test workflow that I did not touch, since they are in the file #394 owns:

- `invalid-host` now receives `litellm-prod.int.jahia.com`, a valid entry, so it will pass while the table documents it as failing. It carried `https://papi.dev.cloud-core.jahia.com` before.
- `denied-host` has its canary on `litellm-prod`, which is not the host tunnelled in that job. It still fails, but on a host that was never tunnelled rather than on the target map refusing the traffic.
- `called-twice` passes the same host with no port on both calls, so the second-port loopback reuse is no longer exercised. It carried `papi.dev.cloud-core.jahia.com:8443` before.

Context: Jahia/cloud-issues#6140.