### PR TITLE
ci: temporary weekday scheduler for the AI incident triage

### DIFF
--- a/.github/workflows/ai-incident-triage-schedule.yml
+++ b/.github/workflows/ai-incident-triage-schedule.yml
@@ -1,0 +1,26 @@
+# TEMPORARY scheduler for the org-wide AI incident triage.
+# The schedule is meant to live in jahia-ee (https://github.com/Jahia/jahia-ee/pull/1713,
+# .github/workflows/ai-incident-triage.yml there), but only jahia-modules-action is currently
+# authorized with the IT mTLS egress broker — so the cron runs here for now.
+# REMOVE THIS WORKFLOW once IT adds Jahia/jahia-ee to the broker's authorized repositories
+# and the jahia-ee scheduler takes over.
+# Note: the broker authorization for this repository was observed for workflow_dispatch
+# events; if the scheduled run is refused a certificate, the schedule event needs the same
+# authorization from IT.
+name: AI Incident Triage Schedule
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 04:00 UTC = 5AM CET (winter) / 6AM CEST (summer), Monday to Friday — GitHub cron is UTC only
+    - cron: '0 4 * * 1-5'
+
+jobs:
+  triage:
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/ai-incident-triage.yml
+    with:
+      post_comments: true
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds a TEMPORARY scheduler workflow: every weekday at 5AM CET (04:00 UTC; 6AM during CEST — GitHub cron is UTC-only) plus manual dispatch, calling the local [`ai-incident-triage.yml`](https://github.com/Jahia/jahia-modules-action/blob/main/.github/workflows/ai-incident-triage.yml) reusable workflow with `post_comments: true` (live posting).

## Why

The schedule is meant to live in jahia-ee ([jahia-ee#1713](https://github.com/Jahia/jahia-ee/pull/1713)), but only this repository is currently authorized with the IT mTLS egress broker — so the cron runs here until IT allowlists `Jahia/jahia-ee`. **Remove this workflow once the jahia-ee scheduler takes over** (called out in the file header).

## Notes

- Uses the local same-commit reference (`uses: ./.github/workflows/ai-incident-triage.yml`), so no `@v2` resolution for the workflow itself; the actions inside still resolve `@v2` and need the next release to include #393.
- The broker authorization observed for this repo covered `workflow_dispatch`; if the first scheduled run is refused a certificate, the `schedule` event needs the same IT authorization.