### PR TITLE
ci: restore ai-incident-triage workflow removed by mistake

### DIFF
--- a/.github/workflows/ai-incident-triage.yml
+++ b/.github/workflows/ai-incident-triage.yml
@@ -1,0 +1,166 @@
+# This workflow triages open "automated-incident" issues (nightly test failures) across the
+# whole organization, from this single repository: a deterministic job searches for issues whose
+# latest failure was not yet analyzed, then a Claude Code agent (running from the cortex harness,
+# reaching internal services through the IT mTLS bastion) analyzes each failed run's logs and
+# posts its conclusion as a comment on the issue. Analysis only — it never changes code.
+#
+# Runs here via workflow_dispatch (the mTLS broker mints certificates exclusively for
+# dispatch-triggered runs of this repository; development iteration = dispatch the feature
+# branch with search_scope narrowed to repo:Jahia/sandbox), and is also callable as a
+# reusable workflow (workflow_call) so another repository can own the schedule — that
+# repository must then be allowlisted with the mTLS broker for its triggering events.
+name: AI Incident Triage
+
+on:
+  workflow_call:
+    inputs:
+      search_scope:
+        description: "GitHub issue-search scope qualifier (e.g. org:Jahia, or repo:Jahia/sandbox)"
+        type: string
+        required: false
+        default: "org:Jahia"
+      dry_run:
+        description: "Only run issue selection; do not start the agent"
+        type: boolean
+        required: false
+        default: false
+      post_comments:
+        description: "Post the triage comment on each issue (false = review mode: store the would-be comments in the run artifact instead)"
+        type: boolean
+        required: false
+        default: false
+      instance_type:
+        description: "Type of instances to run the agent job on"
+        type: string
+        required: false
+        default: "self-hosted"
+      timeout_job:
+        description: "Timeout (in minutes) of the agent job"
+        type: number
+        required: false
+        default: 60
+      cortex_ref:
+        description: "Git ref of the cortex harness to use"
+        type: string
+        required: false
+        default: "main"
+      claude_code_version:
+        description: "Claude Code CLI version to install"
+        type: string
+        required: false
+        default: "stable"
+      tunnel_hosts:
+        description: "Internal hosts to reach through the mTLS tunnel (space-separated); must be allowlisted on IT's side"
+        type: string
+        required: false
+        default: "litellm-prod.int.jahia.com qa.jahia.com"
+  workflow_dispatch:
+    inputs:
+      search_scope:
+        description: "GitHub issue-search scope qualifier (e.g. org:Jahia, or repo:Jahia/sandbox)"
+        type: string
+        required: false
+        default: "org:Jahia"
+      dry_run:
+        description: "Only run issue selection; do not start the agent"
+        type: boolean
+        required: false
+        default: false
+      post_comments:
+        description: "Post the triage comment on each issue (false = review mode: store the would-be comments in the run artifact instead)"
+        type: boolean
+        required: false
+        default: false
+      instance_type:
+        description: "Type of instances to run the agent job on"
+        type: string
+        required: false
+        default: "self-hosted"
+      timeout_job:
+        description: "Timeout (in minutes) of the agent job"
+        type: number
+        required: false
+        default: 60
+      cortex_ref:
+        description: "Git ref of the cortex harness to use"
+        type: string
+        required: false
+        default: "main"
+      claude_code_version:
+        description: "Claude Code CLI version to install"
+        type: string
+        required: false
+        default: "stable"
+      tunnel_hosts:
+        description: "Internal hosts to reach through the mTLS tunnel (space-separated); must be allowlisted on IT's side"
+        type: string
+        required: false
+        default: "litellm-prod.int.jahia.com qa.jahia.com"
+
+jobs:
+  select-issues:
+    name: Select incident issues
+    runs-on: ubuntu-slim
+    outputs:
+      issues: ${{ steps.select.outputs.issues }}
+      has_issues: ${{ steps.select.outputs.has_issues }}
+    steps:
+      - name: Select eligible incident issues
+        id: select
+        uses: jahia/jahia-modules-action/ai-incident-triage/select-issues@v2
+        with:
+          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
+          search_scope: ${{ inputs.search_scope }}
+
+  triage:
+    name: Analyze incidents with Claude Code
+    needs: select-issues
+    if: needs.select-issues.outputs.has_issues == 'true' && !inputs.dry_run
+    runs-on: ${{ inputs.instance_type }}
+    # fromJSON: number-typed dispatch inputs materialize as strings, timeout-minutes needs a number
+    timeout-minutes: ${{ fromJSON(inputs.timeout_job) }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Open the mTLS tunnel to internal Jahia services
+        uses: jahia/jahia-modules-action/mtls-tunnel@v2
+        with:
+          hosts: ${{ inputs.tunnel_hosts || 'litellm-prod.int.jahia.com qa.jahia.com' }}
+          ca-url: ${{ vars.INFRAJAHIA_MTLS_CA_URL }}
+          bastion: ${{ vars.INFRAJAHIA_MTLS_BASTION }}
+          server-name: ci-egress.jahia.com
+          audience: jahia-ci-egress
+          step-root: ${{ secrets.INFRAJAHIA_MTLS_STEP_ROOT }}
+          server-ca: ${{ secrets.INFRAJAHIA_MTLS_SERVER_CA }}
+          canary-url: ${{ vars.AI_LITELLM_BASE_URL }}/health/liveliness
+
+      - name: Set up Claude Code and the cortex harness
+        id: setup
+        uses: jahia/jahia-modules-action/ai-agent-setup@v2
+        with:
+          claude_code_version: ${{ inputs.claude_code_version || 'stable' }}
+          anthropic_base_url: ${{ vars.AI_LITELLM_BASE_URL }}
+          anthropic_auth_token: ${{ secrets.AI_LITELLM_AUTH_TOKEN }}
+          default_opus_model: ${{ vars.AI_LITELLM_ANTHROPIC_DEFAULT_OPUS_MODEL }}
+          default_sonnet_model: ${{ vars.AI_LITELLM_ANTHROPIC_DEFAULT_SONNET_MODEL }}
+          default_haiku_model: ${{ vars.AI_LITELLM_ANTHROPIC_DEFAULT_HAIKU_MODEL }}
+          cortex_ref: ${{ inputs.cortex_ref || 'main' }}
+          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
+
+      - name: Triage the incident issues
+        id: triage
+        uses: jahia/jahia-modules-action/ai-incident-triage@v2
+        with:
+          issues: ${{ needs.select-issues.outputs.issues }}
+          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
+          cortex_path: ${{ steps.setup.outputs.cortex_path }}
+          post_comments: ${{ inputs.post_comments }}
+
+      - name: Upload triage logs
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ai-incident-triage-logs
+          path: ${{ runner.temp }}/triage-logs
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
Restores `.github/workflows/ai-incident-triage.yml`, byte-identical to the version that existed before it was removed.

## Why
[jahia-modules-action#398](https://github.com/Jahia/jahia-modules-action/pull/398) (commit 327729b) removed the AI incident-triage workflows as "moved to jahia-ee", but `ai-incident-triage.yml` was deleted by mistake and is still needed in this repository.

## Changes
- Re-added `.github/workflows/ai-incident-triage.yml` from the pre-deletion commit (22fc011), unchanged.

## Validation
- Verified with `diff` that the restored file is byte-identical to `git show 22fc011:.github/workflows/ai-incident-triage.yml`.

## Documentation
None needed.

## ADR
None.
