### PR TITLE
fix: run the PR Sonar analysis in the pre-warmed mvn-cache container

### DIFF
--- a/.chachalog/sonar-analysis-container.md
+++ b/.chachalog/sonar-analysis-container.md
@@ -1,0 +1,8 @@
+---
+# Allowed version bumps: patch, minor, major
+jahia-modules-action: minor
+---
+
+Fixed the pull-request Sonar analysis failing at random while it downloaded its analyzers.
+
+The `sonar-analysis` job of the `reusable-on-code-change` workflow now runs in the pre-warmed `jahia-docker-mvn-cache` container, so the analyzers are read from the image instead of being downloaded from the SonarQube server on every run. The image can be changed with the new `sonar_analysis_container_image` input.

--- a/.github/workflows/reusable-on-code-change.yml
+++ b/.github/workflows/reusable-on-code-change.yml
@@ -36,6 +36,9 @@ on:
         sonar_analysis_instance_type:
             type: string
             default: "ubuntu-latest"
+        sonar_analysis_container_image:
+            type: string
+            default: "ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded"
         integration_tests_instance_type:
             type: string
             default: "self-hosted"
@@ -155,6 +158,11 @@ jobs:
     sonar-analysis:
         runs-on: ${{ inputs.sonar_analysis_instance_type }}
         needs: build
+        container:
+            image: ${{ inputs.sonar_analysis_container_image }}
+            credentials:
+                username: ${{ secrets.GH_PACKAGES_USERNAME }}
+                password: ${{ secrets.GH_PACKAGES_TOKEN }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:


### PR DESCRIPTION
## What

Run the `sonar-analysis` job of `reusable-on-code-change.yml` in the `jahia-docker-mvn-cache` container, as the `build` job of the same workflow and `reusable-sonar-scan.yml` already do.

New `sonar_analysis_container_image` input, defaulting to the image and tag `build` already defaults to. The `sonar-analysis` action itself is untouched: it already seeds from `/opt/sonar/cache` when the image has one, and falls back to downloading when it does not.

## Why

On a bare runner the job starts with no Maven repository and no Sonar plugin cache, so it re-downloads both on every pull request. The analyzer download fails intermittently and takes the analysis down with it — [Jahia/tools run 32234017450](https://github.com/Jahia/tools/actions/runs/32234017450/job/96010563241?pr=358):

```
[INFO] Load/download plugins (done) | time=8263ms
[ERROR] Fail to download plugin [javascript] into .../fileCache...tmp
Caused by: java.net.SocketException: Connection reset
```

The `v1-sonar-cache` fallback no longer covers this: base-branch scans run in the container, seed from the image and therefore skip the `actions/cache` step, so nothing writes the key any more.

Sampled on the last successful analysis of 7 repositories running the action on a bare runner: all pull 1400-1650 Maven artifacts (225-360 MB) per analysis. Five of them also re-download the analyzers (10-15 s); the other two restore a cache saved before [jahia-modules-action#351](https://github.com/Jahia/jahia-modules-action/pull/351) and kept alive by being read.

## Validated

[Jahia/tools#359](https://github.com/Jahia/tools/pull/359) ran this workflow from this branch ([run 32276410439](https://github.com/Jahia/tools/actions/runs/32276410439)), then went back to `@v2`:

| | bare `ubuntu-latest` | in the container |
|---|---|---|
| Sonar plugin load | 8.3 s, then `Connection reset` | 72 ms |
| Maven artifacts downloaded | ~1500 | 52 |
| Job duration | 3 min 12 s | 1 min 50 s |

`runs-on` does not change, so the runner class and its cost do not either. The image pull costs 61 s and is repaid: the job ends 82 s earlier.

## Scope and next steps

Only repositories that call this reusable workflow benefit, and today that is [`Jahia/javascript-modules`](https://github.com/Jahia/javascript-modules) alone. About 45 repositories still declare the job inline in their own `on-code-change.yml` and keep the bare runner.

The next step is to move those onto this workflow, rather than copy the container block into each of them: they then get this fix and every later one for free. First one is [Jahia/tools#359](https://github.com/Jahia/tools/pull/359), which is also what validated this change.
