### PR TITLE
fix(ai-agent-setup): verify the harness with the cortex-selftest token, not a skill guess

### DIFF
--- a/ai-agent-setup/action.yml
+++ b/ai-agent-setup/action.yml
@@ -183,23 +183,29 @@ runs:
         "
 
     # The hello world proves the gateway; this proves the HARNESS: started from the cortex
-    # checkout, the agent must see cortex's skills — asked about something only cortex knows.
+    # checkout, the agent must see cortex's skills. It asks for the cortex-selftest skill's fixed
+    # token — a string that lives nowhere but that skill. A genuinely loaded harness surfaces it;
+    # a missing one cannot. The token is asked for by the skill's exact name and checked against a
+    # literal, so the result does not depend on the model picking one skill out of ~40 from a fuzzy
+    # description — the coupling that turned a healthy harness red when the model named a skill that
+    # does not exist. The token is a contract with Jahia/cortex; see its ADR-0017.
     - name: Verify the agent sees the cortex harness
       shell: bash
       working-directory: ${{ github.workspace }}/${{ inputs.cortex_path }}
       run: |
         export PATH="$HOME/.local/bin:$PATH"
-        OUTPUT=$(claude -p "Which of the skills available to you here analyzes Jahia module CI Cypress failures? Reply with the skill name only." --permission-mode dontAsk --output-format json 2> /tmp/claude-cortex-check.stderr) || {
+        OUTPUT=$(claude -p "Run the Cortex self-test: use the cortex-selftest skill and reply with ONLY the token it gives you — no other text." --permission-mode dontAsk --output-format json 2> /tmp/claude-cortex-check.stderr) || {
           echo "::error::Cortex harness check failed to run"
           tail -5 /tmp/claude-cortex-check.stderr || true
           exit 1
         }
         printf '%s' "$OUTPUT" | python3 -c "
         import json, sys
+        expected = 'CORTEX-SELFTEST-OK-7fK2aQ9x'
         result = json.load(sys.stdin)
         answer = str(result.get('result', ''))
-        if result.get('is_error') or 'analyze-jahia-ci' not in answer:
-            print('::error::The agent does not see the cortex harness (expected it to name analyze-jahia-ci). Answer: ' + answer[:200])
+        if result.get('is_error') or expected not in answer:
+            print('::error::The agent does not see the cortex harness (expected the cortex-selftest token). Answer: ' + answer[:200])
             sys.exit(1)
-        print(f'Cortex harness OK — agent answered: {answer[:120]!r}')
+        print('Cortex harness OK — cortex-selftest token returned')
         "


### PR DESCRIPTION
## What

Rewires the `ai-agent-setup` harness-verification step (`ai-agent-setup/action.yml`) to ask for the `cortex-selftest` skill's fixed token instead of asking the model to name a skill from a fuzzy description.

## Why

The step verifies that a Claude Code session started in the Cortex checkout has the harness loaded. It did so by asking *"which skill analyzes Jahia CI Cypress failures?"* and matching the answer against `analyze-jahia-ci`.

That couples two unrelated things: **is the harness loaded** (what we want to test) and **does the model pick this one skill out of ~40 from a fuzzy paraphrase** (a reasoning judgement that any newly-added team skill, or a model wobble, can flip).

It failed exactly that way on a healthy harness — [`Jahia/jahia-ee` run 32446222816](https://github.com/Jahia/jahia-ee/actions/runs/32446222816/job/96666215662) went red because the model answered `cypress-regression-analyzer`, a skill that does not exist.

## What changed

The verification step now runs:

> Run the Cortex self-test: use the cortex-selftest skill and reply with ONLY the token it gives you — no other text.

and checks the output against the literal `CORTEX-SELFTEST-OK-7fK2aQ9x`. The token lives nowhere but the `cortex-selftest` skill, so it cannot be hallucinated and no other skill competes for it. The result is deterministic and invariant under skill churn.

## ⚠️ Merge order — this is a draft for a reason

This depends on the `cortex-selftest` skill existing on the `cortex_ref` this action checks out (default `main`):

- **Merge [`Jahia/cortex#225`](https://github.com/Jahia/cortex/pull/225) first.** It adds the skill and ADR-0017.
- Then mark this ready and merge. Merging this **before** cortex#225 asks for a skill that isn't on cortex `main` yet, which makes every consumer's setup step red until cortex#225 lands.

The token is the shared contract between the two repos; each side names the other so a future edit knows to update both.