### PR TITLE
chore(ai-incident-triage): use a dedicated AI_AGENT_GH_ISSUES_PRS_CHORES token

### DIFF
--- a/.github/workflows/ai-incident-triage.yml
+++ b/.github/workflows/ai-incident-triage.yml
@@ -109,7 +109,7 @@ jobs:
         id: select
         uses: jahia/jahia-modules-action/ai-incident-triage/select-issues@v2
         with:
-          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
+          github_token: ${{ secrets.AI_AGENT_GH_ISSUES_PRS_CHORES }}
           search_scope: ${{ inputs.search_scope }}
 
   triage:
@@ -146,14 +146,14 @@ jobs:
           default_sonnet_model: ${{ vars.AI_LITELLM_ANTHROPIC_DEFAULT_SONNET_MODEL }}
           default_haiku_model: ${{ vars.AI_LITELLM_ANTHROPIC_DEFAULT_HAIKU_MODEL }}
           cortex_ref: ${{ inputs.cortex_ref || 'main' }}
-          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
+          github_token: ${{ secrets.AI_AGENT_GH_ISSUES_PRS_CHORES }}
 
       - name: Triage the incident issues
         id: triage
         uses: jahia/jahia-modules-action/ai-incident-triage@v2
         with:
           issues: ${{ needs.select-issues.outputs.issues }}
-          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
+          github_token: ${{ secrets.AI_AGENT_GH_ISSUES_PRS_CHORES }}
           cortex_path: ${{ steps.setup.outputs.cortex_path }}
           post_comments: ${{ inputs.post_comments }}
 


### PR DESCRIPTION
## What

Switches the AI incident-triage workflow to a dedicated GitHub token secret, `AI_AGENT_GH_ISSUES_PRS_CHORES`, instead of the shared `GH_ISSUES_PRS_CHORES`. **Only** `ai-incident-triage.yml` changes.

## Why

`ai-incident-triage.yml` is the AI agent workflow — it runs Claude Code with GitHub access. It shared `GH_ISSUES_PRS_CHORES` with the delivery-chores, integration-tests and Sonar-scan workflows. Giving the agent its own token lets its access be scoped, rotated and audited independently of the rest; the agent is a distinct trust boundary.

## What changed

The three `github_token` inputs in `ai-incident-triage.yml` — passed to `select-issues`, `ai-agent-setup`, and `ai-incident-triage` — now read `secrets.AI_AGENT_GH_ISSUES_PRS_CHORES`.

Left unchanged (still `GH_ISSUES_PRS_CHORES`): `reusable-delivery-pr-chores.yml`, `reusable-delivery-issue-chores.yml`, `reusable-integration-tests.yml`, `reusable-sonar-scan.yml`.

## ⚠️ Before merge

Add the **`AI_AGENT_GH_ISSUES_PRS_CHORES`** secret to this repository (and to any org / consumer that runs this workflow). Without it, the workflow's `github_token` inputs resolve empty and the AI triage run fails at the first authenticated GitHub call.