### PR TITLE
feat(reusable-on-code-change): derive the inputs a module should not have to declare

### DIFF
--- a/.chachalog/on-code-change-inputs.md
+++ b/.chachalog/on-code-change-inputs.md
@@ -3,6 +3,6 @@
 jahia-modules-action: minor
 ---
 
-Reduced what a module must declare to call the `reusable-on-code-change` workflow: the ref under test, the Sonar comparison branch, the test artifact prefix, the Jahia test image and the standalone test run are now derived from the caller's context or from `module_id`. A repository with integration tests needs four inputs instead of eleven.
+Reduced what a module must declare to call the `reusable-on-code-change` workflow: the ref under test, the Sonar comparison branch, the test artifact prefix, the Jahia test image and the standalone test run are now derived from the caller's context or from `module_id`. A repository with integration tests needs four inputs instead of fourteen.
 
-Four defaults changed and may affect a caller that relied on them: `static_analysis_auditci_level` is now `critical`, `integration_tests_should_skip_testrail` is now `true`, `integration_tests_jahia_image` now points at `ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT`, and the Sonar analysis compares against the pull request's base branch instead of `main`. Pass the input explicitly to keep the previous value.
+Five defaults changed and may affect a caller that relied on them: `static_analysis_auditci_level` is now `critical`, `integration_tests_should_skip_testrail` is now `true`, `integration_tests_jahia_image` now points at `ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT`, the test artifacts are prefixed with the module id instead of `tests`, and the Sonar analysis compares against the pull request's base branch instead of `main`. Pass the input explicitly to keep the previous value.

--- a/.chachalog/on-code-change-inputs.md
+++ b/.chachalog/on-code-change-inputs.md
@@ -1,0 +1,8 @@
+---
+# Allowed version bumps: patch, minor, major
+jahia-modules-action: minor
+---
+
+Reduced what a module must declare to call the `reusable-on-code-change` workflow: the ref under test, the Sonar comparison branch, the test artifact prefix, the Jahia test image and the standalone test run are now derived from the caller's context or from `module_id`. A repository with integration tests needs four inputs instead of eleven.
+
+Four defaults changed and may affect a caller that relied on them: `static_analysis_auditci_level` is now `critical`, `integration_tests_should_skip_testrail` is now `true`, `integration_tests_jahia_image` now points at `ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT`, and the Sonar analysis compares against the pull request's base branch instead of `main`. Pass the input explicitly to keep the previous value.

--- a/.chachalog/on-code-change-inputs.md
+++ b/.chachalog/on-code-change-inputs.md
@@ -1,8 +1,0 @@
----
-# Allowed version bumps: patch, minor, major
-jahia-modules-action: minor
----
-
-Reduced what a module must declare to call the `reusable-on-code-change` workflow: the ref under test, the Sonar comparison branch, the test artifact prefix, the Jahia test image and the standalone test run are now derived from the caller's context or from `module_id`. A repository with integration tests needs four inputs instead of fourteen.
-
-Five defaults changed and may affect a caller that relied on them: `static_analysis_auditci_level` is now `critical`, `integration_tests_should_skip_testrail` is now `true`, `integration_tests_jahia_image` now points at `ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT`, the test artifacts are prefixed with the module id instead of `tests`, and the Sonar analysis compares against the pull request's base branch instead of `main`. Pass the input explicitly to keep the previous value.

--- a/.github/workflows/reusable-on-code-change.yml
+++ b/.github/workflows/reusable-on-code-change.yml
@@ -21,7 +21,7 @@ on:
         static_analysis_auditci_level:
             type: string
             default: "critical"
-            description: "Severity at which audit-ci fails. A module that gates on a lower severity than critical must keep declaring it."
+            description: "Severity at which audit-ci fails. A module that gates lower than critical must keep declaring it, on every branch that runs this workflow."
         static_analysis_node_version:
             type: number
             default: 18
@@ -94,7 +94,7 @@ on:
         integration_tests_should_skip_testrail:
             type: boolean
             default: true
-            description: "TestRail is not published from a pull request. Set to false to publish from this workflow."
+            description: "Skips publishing to TestRail, which is what a pull-request run wants. Set to false to publish."
         integration_tests_should_skip_pagerduty:
             type: boolean
             default: false
@@ -196,7 +196,6 @@ jobs:
             jahia_image: ${{ inputs.integration_tests_jahia_image }}
             pagerduty_skip_notification: ${{ inputs.integration_tests_pagerduty_skip_notification }}
             provisioning_manifest: ${{ inputs.integration_tests_provisioning_manifest }}
-            should_use_build_artifacts: ${{ inputs.integration_tests_should_use_build_artifacts }}
             artifact_prefix: standalone-${{ inputs.integration_tests_artifact_prefix || inputs.module_id }}
             module_branch: ${{ inputs.module_branch || github.ref }}
             timeout_job: ${{ inputs.integration_tests_timeout }}
@@ -220,7 +219,6 @@ jobs:
             jahia_image: ${{ inputs.integration_tests_jahia_image }}
             pagerduty_skip_notification: ${{ inputs.integration_tests_pagerduty_skip_notification }}
             provisioning_manifest: ${{ inputs.integration_tests_provisioning_manifest }}
-            should_use_build_artifacts: ${{ inputs.integration_tests_should_use_build_artifacts }}
             artifact_prefix: cluster-${{ inputs.integration_tests_artifact_prefix || inputs.module_id }}
             module_branch: ${{ inputs.module_branch || github.ref }}
             timeout_job: ${{ inputs.integration_tests_timeout }}

--- a/.github/workflows/reusable-on-code-change.yml
+++ b/.github/workflows/reusable-on-code-change.yml
@@ -48,7 +48,7 @@ on:
         integration_tests_standalone_execute:
             type: boolean
             default: false
-            description: "Forces the standalone run. Left false, it runs anyway when a provisioning manifest is given and no cluster run is requested."
+            description: "Forces the standalone run. It also runs on its own when a provisioning manifest is given and no cluster run is requested, so setting this to false does not turn the tests off — remove integration_tests_provisioning_manifest for that."
         integration_tests_cluster_execute:
             type: boolean
             default: false
@@ -127,7 +127,7 @@ jobs:
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:
-                ref: ${{ inputs.module_branch || github.ref }}
+                ref: ${{ inputs.module_branch }}
             - uses: jahia/jahia-modules-action/update-signature@v2
               with:
                 nexus_internal_releases_url: ${{ secrets.NEXUS_INTERNAL_RELEASES_URL }}
@@ -139,7 +139,7 @@ jobs:
       steps:
         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
           with:
-            ref: ${{ inputs.module_branch || github.ref }}
+            ref: ${{ inputs.module_branch }}
         - uses: jahia/jahia-modules-action/static-analysis@v2
           with:
             node_version: ${{ inputs.static_analysis_node_version }}
@@ -157,7 +157,7 @@ jobs:
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:
-                ref: ${{ inputs.module_branch || github.ref }}
+                ref: ${{ inputs.module_branch }}
             - uses: jahia/jahia-modules-action/build@v2
               with:
                 mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
@@ -175,7 +175,7 @@ jobs:
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:
-                ref: ${{ inputs.module_branch || github.ref }}
+                ref: ${{ inputs.module_branch }}
             - uses: jahia/jahia-modules-action/sonar-analysis@v2
               with:
                 primary_release_branch: ${{ inputs.sonar_analysis_primary_release_branch || github.event.pull_request.base.ref || github.event.repository.default_branch || 'main' }}

--- a/.github/workflows/reusable-on-code-change.yml
+++ b/.github/workflows/reusable-on-code-change.yml
@@ -21,6 +21,7 @@ on:
         static_analysis_auditci_level:
             type: string
             default: "critical"
+            description: "Severity at which audit-ci fails. A module that gates on a lower severity than critical must keep declaring it."
         static_analysis_node_version:
             type: number
             default: 18
@@ -71,6 +72,7 @@ on:
         integration_tests_jahia_image:
             type: string
             default: "ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT"
+            description: "Jahia image the tests run against. This value is passed down, so it also overrides whatever the module's own docker-compose.yml falls back to."
         integration_tests_pagerduty_incident_service:
             type: string
             default: ""
@@ -92,9 +94,11 @@ on:
         integration_tests_should_skip_testrail:
             type: boolean
             default: true
+            description: "TestRail is not published from a pull request. Set to false to publish from this workflow."
         integration_tests_should_skip_pagerduty:
             type: boolean
             default: false
+            description: "DEPRECATED and ignored — never forwarded to the test run. Use integration_tests_pagerduty_skip_notification."
         sbom_execute:
             type: boolean
             default: false
@@ -174,7 +178,7 @@ jobs:
                 ref: ${{ inputs.module_branch || github.ref }}
             - uses: jahia/jahia-modules-action/sonar-analysis@v2
               with:
-                primary_release_branch: ${{ inputs.sonar_analysis_primary_release_branch || github.event.pull_request.base.ref || github.event.repository.default_branch }}
+                primary_release_branch: ${{ inputs.sonar_analysis_primary_release_branch || github.event.pull_request.base.ref || github.event.repository.default_branch || 'main' }}
                 github_pr_id: ${{github.event.number}}
                 sonar_url: ${{ secrets.SONAR_URL }}
                 sonar_token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/reusable-on-code-change.yml
+++ b/.github/workflows/reusable-on-code-change.yml
@@ -9,8 +9,9 @@ on:
             type: string
             default: ".github/maven.settings.xml"
         module_branch:
-            required: true
             type: string
+            default: ""
+            description: "Ref to check out and test. Defaults to the ref that triggered the caller."
         update_signature_execute:
             type: boolean
             default: false
@@ -19,7 +20,7 @@ on:
             default: "ubuntu-latest"
         static_analysis_auditci_level:
             type: string
-            default: "moderate"
+            default: "critical"
         static_analysis_node_version:
             type: number
             default: 18
@@ -32,7 +33,8 @@ on:
             default: "ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded"
         sonar_analysis_primary_release_branch:
             type: string
-            default: "main"
+            default: ""
+            description: "Branch the analysis compares against. Defaults to the base branch of the pull request, then to the repository default branch."
         sonar_analysis_instance_type:
             type: string
             default: "ubuntu-latest"
@@ -45,6 +47,7 @@ on:
         integration_tests_standalone_execute:
             type: boolean
             default: false
+            description: "Forces the standalone run. Left false, it runs anyway when a provisioning manifest is given and no cluster run is requested."
         integration_tests_cluster_execute:
             type: boolean
             default: false
@@ -60,12 +63,14 @@ on:
         integration_tests_should_use_build_artifacts:
             type: boolean
             default: false
+            description: "DEPRECATED and ignored — build artifacts are downloaded whenever they are available."
         integration_tests_artifact_prefix:
             type: string
-            default: "tests"
+            default: ""
+            description: "Prefix of the test artifacts, after the run type. Defaults to module_id."
         integration_tests_jahia_image:
             type: string
-            default: ""
+            default: "ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT"
         integration_tests_pagerduty_incident_service:
             type: string
             default: ""
@@ -86,7 +91,7 @@ on:
             default: ""
         integration_tests_should_skip_testrail:
             type: boolean
-            default: false
+            default: true
         integration_tests_should_skip_pagerduty:
             type: boolean
             default: false
@@ -118,7 +123,7 @@ jobs:
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:
-                ref: ${{ inputs.module_branch }}
+                ref: ${{ inputs.module_branch || github.ref }}
             - uses: jahia/jahia-modules-action/update-signature@v2
               with:
                 nexus_internal_releases_url: ${{ secrets.NEXUS_INTERNAL_RELEASES_URL }}
@@ -130,7 +135,7 @@ jobs:
       steps:
         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
           with:
-            ref: ${{ inputs.module_branch }}
+            ref: ${{ inputs.module_branch || github.ref }}
         - uses: jahia/jahia-modules-action/static-analysis@v2
           with:
             node_version: ${{ inputs.static_analysis_node_version }}
@@ -148,7 +153,7 @@ jobs:
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:
-                ref: ${{ inputs.module_branch }}
+                ref: ${{ inputs.module_branch || github.ref }}
             - uses: jahia/jahia-modules-action/build@v2
               with:
                 mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
@@ -166,17 +171,17 @@ jobs:
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:
-                ref: ${{ inputs.module_branch }}
+                ref: ${{ inputs.module_branch || github.ref }}
             - uses: jahia/jahia-modules-action/sonar-analysis@v2
               with:
-                primary_release_branch: ${{ inputs.sonar_analysis_primary_release_branch }}
+                primary_release_branch: ${{ inputs.sonar_analysis_primary_release_branch || github.event.pull_request.base.ref || github.event.repository.default_branch }}
                 github_pr_id: ${{github.event.number}}
                 sonar_url: ${{ secrets.SONAR_URL }}
                 sonar_token: ${{ secrets.SONAR_TOKEN }}
                 mvn_settings_filepath: ${{ inputs.mvn_settings_filepath }}
 
     integration-tests-standalone:
-        if: ${{ inputs.integration_tests_standalone_execute }}
+        if: ${{ inputs.integration_tests_standalone_execute || (inputs.integration_tests_provisioning_manifest != '' && !inputs.integration_tests_cluster_execute) }}
         needs: build
         secrets: inherit
         uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
@@ -188,8 +193,8 @@ jobs:
             pagerduty_skip_notification: ${{ inputs.integration_tests_pagerduty_skip_notification }}
             provisioning_manifest: ${{ inputs.integration_tests_provisioning_manifest }}
             should_use_build_artifacts: ${{ inputs.integration_tests_should_use_build_artifacts }}
-            artifact_prefix: standalone-${{ inputs.integration_tests_artifact_prefix }}
-            module_branch: ${{ inputs.module_branch }}
+            artifact_prefix: standalone-${{ inputs.integration_tests_artifact_prefix || inputs.module_id }}
+            module_branch: ${{ inputs.module_branch || github.ref }}
             timeout_job: ${{ inputs.integration_tests_timeout }}
             timeout_step: ${{ inputs.integration_tests_timeout_step }}
             tests_profile: ${{ inputs.integration_tests_profile }}
@@ -212,8 +217,8 @@ jobs:
             pagerduty_skip_notification: ${{ inputs.integration_tests_pagerduty_skip_notification }}
             provisioning_manifest: ${{ inputs.integration_tests_provisioning_manifest }}
             should_use_build_artifacts: ${{ inputs.integration_tests_should_use_build_artifacts }}
-            artifact_prefix: cluster-${{ inputs.integration_tests_artifact_prefix }}
-            module_branch: ${{ inputs.module_branch }}
+            artifact_prefix: cluster-${{ inputs.integration_tests_artifact_prefix || inputs.module_id }}
+            module_branch: ${{ inputs.module_branch || github.ref }}
             timeout_job: ${{ inputs.integration_tests_timeout }}
             timeout_step: ${{ inputs.integration_tests_timeout_step }}
             tests_profile: ${{ inputs.integration_tests_profile }}


### PR DESCRIPTION
## What

Cut what a module has to declare to call `reusable-on-code-change.yml`. Inputs that repeat a fact the workflow can read from its own context are now derived; inputs that carried the same value in every caller got that value as their default.

`Jahia/siteSettings` goes from fourteen inputs to four:

```yaml
with:
  module_id: siteSettings
  update_signature_execute: true
  integration_tests_provisioning_manifest: provisioning-manifest-build.yml
  integration_tests_testrail_project: Site Settings   # only takes effect once should_skip_testrail is false
```

That drops two inputs the workflow does not derive, on purpose. `integration_tests_timeout: 45` is a cap rather than a target, and one shared timeout is the consistency this change is after. `integration_tests_pagerduty_skip_notification: false` is inert on a pull-request run: notifications also require `CURRENT_BRANCH` to be `master`, `main` or the primary release branch, and it is `<n>-merge`.

## Derived instead of declared

| Input | Now falls back to |
|---|---|
| `module_branch` (was required) | `github.ref` — the ref that triggered the caller |
| `sonar_analysis_primary_release_branch` (was `main`) | the base branch of the pull request, then the repository default branch, then `main` |
| `integration_tests_artifact_prefix` (was `tests`) | `module_id` |
| `integration_tests_standalone_execute` | runs when a provisioning manifest is given and no cluster run is requested |

The fallbacks are resolved in the jobs (`inputs.x || …`), not in `default:`, so they stay context-safe.

## Defaults retuned

| Input | Was | Now | Why |
|---|---|---|---|
| `static_analysis_auditci_level` | `moderate` | `critical` | what 113 of the 144 `on-code-change.yml` in the organisation pass |
| `integration_tests_should_skip_testrail` | `false` | `true` | what a pull-request run wants, and every caller triggers on pull requests today |
| `integration_tests_jahia_image` | `""` | `ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT` | `jahia_image` is required downstream, and this is the value callers pass |
| `integration_tests_artifact_prefix` | `tests` | `module_id` | see above; it renames the test artifacts |

`integration_tests_should_use_build_artifacts` is documented as deprecated and no longer forwarded to either test job: the underlying action carries `deprecationMessage: This input is deprecated. Build artifacts are now downloaded if available` and reads it nowhere, the integration-tests workflow never forwarded it either, and the download runs off `build_artifacts` unconditionally. `integration_tests_should_skip_pagerduty` gets the same treatment for a different reason — it is declared here but never forwarded to either test job, so setting it has never done anything.

## Removes a trap rather than fixing a live bug

`sonar_analysis_primary_release_branch` becomes `-Dsonar.pullrequest.base`. A hardcoded `main` is the wrong new-code baseline for a pull request opened against a maintenance branch, and 14 repositories in the organisation still declare `master`. No repository experiences that today: both consumers pass the input explicitly, and the maintenance branches of the nearest migration target (`Jahia/siteSettings` `8_7_x`, `8_12_x`) still carry inline jobs, so a pull request against them uses their own workflow file, not this one. The fix is latent-correct — it stops the trap from being sprung by the migrations to come.

Untested end to end: no repository in the organisation passes a maintenance branch as `sonar.pullrequest.base` today, so whether SonarQube accepts one that has never had a branch analysis is unverified. Worth one throw-away pull request into `8_7_x` after the migration reaches it.

## Validated

[Jahia/javascript-modules#726](https://github.com/Jahia/javascript-modules/pull/726) — a throw-away pull request — calls this branch with four inputs instead of eleven. Its [run 32485354032](https://github.com/Jahia/javascript-modules/actions/runs/32485354032) — which resolved this branch at its head — is green, integration tests included, and each dropped input resolved as intended:

| Dropped input | Observed in the run |
|---|---|
| `module_branch` | jobs checked out `refs/pull/726/merge` |
| `sonar_analysis_primary_release_branch` | `sonar.pullrequest.base=main`, from the base of the pull request |
| `integration_tests_standalone_execute` | the standalone job ran and passed, the cluster job stayed skipped |
| `integration_tests_jahia_image` | `JAHIA_IMAGE=ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT` |
| `integration_tests_artifact_prefix` | artifacts named `standalone-javascript-modules-engine-1397`, previously `standalone-tests-<run>` |
| `integration_tests_should_skip_testrail` | `should_skip_testrail: true` |
| `integration_tests_should_use_build_artifacts` | `build-artifacts` still downloaded, confirming the input is inert |
| `static_analysis_auditci_level` | `audit-ci --skip-dev --critical` |

The `integration_tests_cluster_execute` path is reasoned, not exercised: no repository runs cluster tests through this workflow today.

## What a migrating author must watch

- **A module that gates on a severity below `critical` has to keep declaring it.** `Jahia/jahia-ui-root`, `Jahia/jahia-user-entries` and `Jahia/jahia-developer-tools` pass `auditci_level: high` on their default branch, and `Jahia/siteSettings` does the same on `8_7_x`, so maintenance branches need checking too. Dropping the input there would loosen the gate, and it would do so silently — fewer findings, no error. One repository has nothing to carry over and would loosen anyway: `Jahia/jahia-authentication` runs `static-analysis` with no level and has a root `package.json`, so it gates at `moderate` today and would move to `critical` on migration. 113 of the 144 `on-code-change.yml` in the organisation pass `critical`, which is what makes it the right default. The input description says so. Note this leaves the workflow default (`critical`) and the `static-analysis` action default (`moderate`) disagreeing — deliberately: retuning the action would silently loosen the gate for the ~45 repositories that call it directly, which belongs in its own change.
- **Turning integration tests off is now done by removing the provisioning manifest**, not by setting `integration_tests_standalone_execute: false`. With a manifest present and no cluster run requested, the standalone job runs regardless of that flag. A cluster-only setup still works by passing `integration_tests_cluster_execute: true`.
- **The Jahia image default is passed down explicitly**, so it also overrides whatever a module's own `tests/docker-compose.yml` falls back to. All 33 repositories that run integration tests from `on-code-change.yml` already set `jahia_image` explicitly, so no migrating module inherits this default by accident. It also closes a hole: `Jahia/javascript-modules`' `tests/docker-compose.yml` reads a bare `${JAHIA_IMAGE}` with no fallback, so the previous empty default produced an invalid image reference. Note the flip side — a version-bearing tag as a shared default moves the Jahia-version decision from the module to the harness, and will retarget every caller that dropped the input when `9-SNAPSHOT` arrives.
- **`update_signature_execute` still has to be declared.** See below.

## Risk

Five defaults change behaviour for a caller that relied on them; passing the input explicitly keeps the old value.

Both current consumers are safe. `Jahia/tools` passes every retuned and derived input, so nothing changes for it at all. `Jahia/javascript-modules` passes all of them except `integration_tests_artifact_prefix`, so its test artifacts are renamed from `standalone-tests-<run>` to `standalone-javascript-modules-engine-<run>`; no workflow file in any non-archived repository of the organisation references `standalone-tests` or `cluster-tests`, though anything outside `.github/workflows` globbing the old name would miss.

Three migrations are open — [Jahia/default#160](https://github.com/Jahia/default/pull/160) and [Jahia/module-manager#203](https://github.com/Jahia/module-manager/pull/203) are ready for review, [Jahia/siteSettings#286](https://github.com/Jahia/siteSettings/pull/286) is draft. All three are immune whichever order things land in: the first two declare no `integration_tests_*` input at all and run no integration tests, and `siteSettings` passes each retuned input explicitly. They can be trimmed afterwards. About 45 repositories are still to migrate — retuning a default after they adopt it would be an org-wide event, which is the reason to do it now.

## Not in this PR

The module signature. `update_signature_execute` still defaults to `false`, and the `update-signature` action is still a fixer that only acts on a `[ci sign]` commit, so it cannot fail a pull request whose signature is wrong. Making it verify, and gating the integration tests on it, needs a change to the action and a survey of which repositories would go red — its own PR. Until then a caller that wants the signature job must keep declaring `update_signature_execute: true`.
