### PR TITLE
ci(release): include the release notes in the Slack announcement

### DIFF
--- a/.chachalog/slack-release-notes.md
+++ b/.chachalog/slack-release-notes.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+jahia-modules-action: minor
+---
+
+Added the release notes to the Slack release announcement, so the channel shows what changed without opening GitHub.

--- a/.github/scripts/render_slack_payload.py
+++ b/.github/scripts/render_slack_payload.py
@@ -1,0 +1,66 @@
+"""Render a GitHub release body as the Slack payload announcing that release.
+
+Usage: render_slack_payload.py <repository> <release-tag> <major-tag> < body.md
+
+Reads the release body (GitHub-flavoured Markdown) on stdin and prints, on a
+single line, the JSON payload for an incoming webhook: a header section naming
+the release and the major tag that now points at it, then the converted notes.
+
+Slack's mrkdwn is not Markdown — bold is *one* star, links are <url|label> and
+headings do not exist — so the body is translated rather than passed through.
+"""
+import json
+import re
+import sys
+
+# A section block's text tops out at 3000 characters; stay clear of the edge so
+# the truncation footer always fits.
+SECTION_LIMIT = 2800
+
+repository, release_tag, major_tag = sys.argv[1], sys.argv[2], sys.argv[3]
+release_url = f'https://github.com/{repository}/releases/tag/{release_tag}'
+
+
+def to_mrkdwn(body):
+    text = body.replace('\r\n', '\n').replace('\r', '\n')
+    # The generated-notes marker and any other HTML comment are invisible on
+    # GitHub but would show up verbatim in Slack.
+    text = re.sub(r'<!--.*?-->', '', text, flags=re.S)
+    # Escape before emitting any link of our own, or the < and > we are about to
+    # write get escaped too and the links arrive as text.
+    text = text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+    text = re.sub(r'(?m)^#{1,6}\s*(.+?)\s*$', r'*\1*', text)
+    # Before the list bullets below, which would otherwise consume the stars.
+    text = re.sub(r'\*\*(.+?)\*\*', r'*\1*', text, flags=re.S)
+    text = re.sub(r'\[([^\]]+)\]\((https?://[^\s)]+)\)', r'<\2|\1>', text)
+    # Bare pull-request and compare URLs carry no information in their path that
+    # a reader needs; label them so a line of notes stays readable.
+    text = re.sub(
+        r'(?<![|<])https://github\.com/([\w.-]+/[\w.-]+)/pull/(\d+)',
+        lambda m: f'<https://github.com/{m[1]}/pull/{m[2]}|#{m[2]}>', text)
+    text = re.sub(
+        r'(?<![|<])https://github\.com/([\w.-]+/[\w.-]+)/compare/(\S+)',
+        lambda m: f'<https://github.com/{m[1]}/compare/{m[2]}|{m[2]}>', text)
+    text = re.sub(r'(?m)^\s*[*-]\s+', '• ', text)
+    # The header block already says which release this is.
+    text = re.sub(r"(?m)^\*What's Changed\*\s*$", '', text)
+    return re.sub(r'\n{3,}', '\n\n', text).strip()
+
+
+notes = to_mrkdwn(sys.stdin.read())
+if len(notes) > SECTION_LIMIT:
+    notes = (notes[:SECTION_LIMIT].rsplit('\n', 1)[0]
+             + f'\n\n… <{release_url}|read the full release notes>')
+
+blocks = [{
+    'type': 'section',
+    'text': {
+        'type': 'mrkdwn',
+        'text': f':rocket: *<{release_url}|{repository} {release_tag}>* released'
+                f' — the `{major_tag}` tag now points to it.',
+    },
+}]
+if notes:
+    blocks.append({'type': 'section', 'text': {'type': 'mrkdwn', 'text': notes}})
+
+print(json.dumps({'blocks': blocks}))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,60 @@ jobs:
     name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+
       - name: Update the ${{ env.TAG_NAME }} tag
+        id: update_tag
         uses: actions/publish-action@23f4c6f12633a2da8f44938b71fde9afec138fb4 # v0.4.0
         with:
           source-tag: ${{ env.TAG_NAME }}
-          slack-webhook: ${{ secrets.SLACK_WEBHOOK_RELEASE_NOTIFICATION }}
           token: ${{ secrets.GH_API_TOKEN }}
+          # slack-webhook is deliberately not passed: the action's own message is
+          # a fixed string it gives no way to extend, and the steps below send a
+          # richer one to the same channel.
+
+      # The release event carries the body, a manual dispatch does not, so read it
+      # from the API in both cases and keep a single code path.
+      - name: Build the Slack announcement
+        id: announcement
+        env:
+          GH_TOKEN: ${{ secrets.GH_API_TOKEN }}
+          MAJOR_TAG: ${{ steps.update_tag.outputs.major-tag }}
+        run: |
+          set -euo pipefail
+          gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --json body --jq '.body // ""' \
+            | python3 .github/scripts/render_slack_payload.py \
+                "$GITHUB_REPOSITORY" "$TAG_NAME" "$MAJOR_TAG" > "$RUNNER_TEMP/payload.json"
+          echo "payload=$(cat "$RUNNER_TEMP/payload.json")" >> "$GITHUB_OUTPUT"
+
+      # payload, not payload-file-path: the file variant strips the first "$" of
+      # the file and expands {{ ... }} against the GitHub context, which would
+      # corrupt any release note quoting a workflow expression.
+      - name: Announce the release on Slack
+        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
+        with:
+          payload: ${{ steps.announcement.outputs.payload }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_RELEASE_NOTIFICATION }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+      # Replaces the failure notification the publish-action webhook used to send.
+      - name: Report the failure on Slack
+        if: failure()
+        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":x: The release job for *${{ github.repository }} ${{ env.TAG_NAME }}* failed — the major tag or its announcement may not be up to date — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|see the run>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_RELEASE_NOTIFICATION }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,22 +45,25 @@ jobs:
                 "$GITHUB_REPOSITORY" "$TAG_NAME" "$MAJOR_TAG" > "$RUNNER_TEMP/payload.json"
           echo "payload=$(cat "$RUNNER_TEMP/payload.json")" >> "$GITHUB_OUTPUT"
 
-      # payload, not payload-file-path: the file variant strips the first "$" of
-      # the file and expands {{ ... }} against the GitHub context, which would
-      # corrupt any release note quoting a workflow expression.
+      # payload-templated must stay off (its default): it expands {{ ... }} inside
+      # the payload against the GitHub context, which would corrupt any release
+      # note quoting a workflow expression.
       - name: Announce the release on Slack
-        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_RELEASE_NOTIFICATION }}
+          webhook-type: incoming-webhook
           payload: ${{ steps.announcement.outputs.payload }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_RELEASE_NOTIFICATION }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          # A release nobody hears about should turn the run red, not pass quietly.
+          errors: true
 
       # Replaces the failure notification the publish-action webhook used to send.
       - name: Report the failure on Slack
         if: failure()
-        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_RELEASE_NOTIFICATION }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "blocks": [
@@ -73,6 +76,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_RELEASE_NOTIFICATION }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## Summary

The Slack message announcing a `jahia-modules-action` release now carries the release notes, instead of only stating that the major tag moved.

## Why

The announcement in `#product-cicd` was produced by `actions/publish-action`, which posts one hardcoded sentence — `The v2 tag has been successfully updated for the jahia-modules-action action to include changes from v2.65.0`. The action exposes no input to extend it, so the notes could not be added by configuration: the only way is to stop letting it post and send our own message. Readers of the channel had to open the release on GitHub to learn what actually changed.

## Changes

- `actions/publish-action` no longer receives `slack-webhook`. It still moves the major tag; the announcement is now ours.
- A new step reads the release body and renders it as Slack blocks: a header line with the release link and the major tag that now points at it, then the notes.
- `.github/scripts/render_slack_payload.py` translates GitHub-flavoured Markdown into Slack `mrkdwn` — headings become bold lines, `**bold**` becomes `*bold*`, Markdown links and bare pull-request/compare URLs become labelled `<url|label>` links, list markers become bullets, and the generated-notes HTML comment is dropped.
- A `failure()` step replaces the failure notification that the `publish-action` webhook used to send, so a broken release run is still reported.
- Both Slack steps use `slackapi/slack-github-action` **v4.0.0**, not the v1.23.0 pinned elsewhere in this repository. v1.23.0 dates from 2023 and runs on the deprecated `node16`; v4 runs on `node24`, takes the webhook as an input instead of an environment variable, and retries failed requests. See the note below on the remaining v1.23.0 pins.
- The body is read with `gh release view` rather than from `github.event.release`, because a `workflow_dispatch` run has no release object. Both triggers now follow one code path.

The same secret is reused, so the message lands in the same channel — an incoming webhook is bound to its channel.

## Notable details

`payload-templated` is left at its default of `false`. When enabled it expands `{{ ... }}` inside the payload against the GitHub context, which would corrupt any release note quoting a workflow expression — a real risk for this repository in particular. The comment in the workflow says so, because the failure mode only shows up in the rendered message.

This was worth checking rather than assuming: in v1.23.0 the equivalent templating was **not** optional on the `payload-file-path` route, which also stripped the first `$` of the file. v4 gates both payload routes behind the flag.

`errors: true` on the announcement step is deliberate — a release whose announcement silently failed to send is worse than a red run. The failure-reporting step keeps the default so it cannot cascade.

A section block's text is capped at 3000 characters, so the notes are truncated at 2800 with a link to the full release. For reference, the last twelve release bodies ran 350–900 characters, so truncation should stay rare.

## Validation

- [x] The renderer was run against the real `v2.65.0` and `v2.61.0` release bodies; both produce valid single-line JSON with every section inside the 3000-character limit.
- [x] Edge cases covered: an empty body and a comment-only body degrade to the header block alone (no empty section, which Slack rejects); an 8 KB body truncates correctly; a body quoting `${{ secrets.X }}` survives intact, and `&`, `<`, `>` are escaped before any link is emitted.
- [x] The workflow step was simulated locally end to end — `gh release view` piped into the renderer, written to `$GITHUB_OUTPUT`, and parsed back as valid JSON.
- [ ] Not yet exercised by a real release; the first release after merge is the live check.

## Follow-up, not in this PR

Five other pins of `slackapi/slack-github-action@v1.23.0` remain, in `slack-jahia`, `release`, and `release-javascript`. They are on the same deprecated `node16` runtime and each needs the environment-variable-to-input migration plus its own testing, so they are left alone here rather than bundled into a release-workflow change. Worth its own PR.

`actions/publish-action@v0.4.0` is already the latest tag and the repository is active, so that pin stays. `actions/checkout` is pinned to v6.0.2 to match the fourteen other pins in this repository, even though v7.0.1 exists — bumping it belongs in a sweep, not here.

## Documentation

None needed. The change is internal to this repository's own release workflow and adds no action surface that modules consume.

## ADR

None.
